### PR TITLE
refactor(core): rename and enhance executor-origin conversion utilities

### DIFF
--- a/packages/core/src/lib/orchestrator/orchestrator.ts
+++ b/packages/core/src/lib/orchestrator/orchestrator.ts
@@ -818,12 +818,13 @@ export class Orchestrator {
       value: bigint;
     };
 
-    const ueaOrigin = await PushChain.utils.account.convertExecutorToOrigin(
-      tx.to as `0x${string}`
-    );
+    const ueaOrigin =
+      await PushChain.utils.account.convertExecutorToOriginAccount(
+        tx.to as `0x${string}`
+      );
     let originAddress: string;
 
-    if (ueaOrigin.isUEA) {
+    if (ueaOrigin.exists) {
       if (!ueaOrigin.account) {
         throw new Error('UEA origin account is null');
       }

--- a/packages/core/src/lib/universal/account/account.spec.ts
+++ b/packages/core/src/lib/universal/account/account.spec.ts
@@ -91,19 +91,20 @@ describe('Universal Account Utilities', () => {
     });
   });
 
-  describe('convertExecutorToOrigin()', () => {
+  describe('convertExecutorToOriginAccount()', () => {
     it('Solana: should return valid origin data for a UEA address', async () => {
       const testAddress = '0xc16a585b95810F7D204620bb3677F73243242A8F';
 
-      const result = await PushChain.utils.account.convertExecutorToOrigin(
-        testAddress
-      );
+      const result =
+        await PushChain.utils.account.convertExecutorToOriginAccount(
+          testAddress
+        );
 
-      // Validate the result structure - should be a tuple [account, isUEA]
+      // Validate the result structure - should be an object { account, exists }
       expect(result).toHaveProperty('account');
-      expect(result).toHaveProperty('isUEA');
+      expect(result).toHaveProperty('exists');
 
-      const { account, isUEA } = result;
+      const { account, exists } = result;
 
       // Validate the account object structure
       expect(account).toEqual({
@@ -111,22 +112,23 @@ describe('Universal Account Utilities', () => {
         address: 'FNDJWigdNWsmxXYGrFV2gCvioLYwXnsVxZ4stL33wFHf',
       });
 
-      // Validate isUEA flag
-      expect(isUEA).toBe(true);
+      // Validate exists flag
+      expect(exists).toBe(true);
     }, 30000); // 30 second timeout for network call
 
     it('Ethereum: should return valid origin data for a UEA address', async () => {
       const testAddress = '0xea3Eff68C6Ac7e91dDf975643bc6747b30aC1355';
 
-      const result = await PushChain.utils.account.convertExecutorToOrigin(
-        testAddress
-      );
+      const result =
+        await PushChain.utils.account.convertExecutorToOriginAccount(
+          testAddress
+        );
 
-      // Validate the result structure - should be a tuple [account, isUEA]
+      // Validate the result structure - should be an object { account, exists }
       expect(result).toHaveProperty('account');
-      expect(result).toHaveProperty('isUEA');
+      expect(result).toHaveProperty('exists');
 
-      const { account, isUEA } = result;
+      const { account, exists } = result;
 
       // Validate the account object structure
       expect(account).toEqual({
@@ -134,29 +136,30 @@ describe('Universal Account Utilities', () => {
         address: getAddress('0xfd6c2fe69be13d8be379ccb6c9306e74193ec1a9'),
       });
 
-      // Validate isUEA flag
-      expect(isUEA).toBe(true);
+      // Validate exists flag
+      expect(exists).toBe(true);
     }, 30000); // 30 second timeout for network call
 
     it('Push Address WITH transactions: should return valid origin data for a UEA address', async () => {
       // Push Address that has transactions on it
       const testAddress = '0xFd6C2fE69bE13d8bE379CCB6c9306e74193EC1A9';
 
-      const result = await PushChain.utils.account.convertExecutorToOrigin(
-        testAddress
-      );
+      const result =
+        await PushChain.utils.account.convertExecutorToOriginAccount(
+          testAddress
+        );
 
-      // Validate the result structure - should be a tuple [account, isUEA]
+      // Validate the result structure - should be a object { account, exists }
       expect(result).toHaveProperty('account');
-      expect(result).toHaveProperty('isUEA');
+      expect(result).toHaveProperty('exists');
 
-      const { account, isUEA } = result;
+      const { account, exists } = result;
 
       // Validate the account object structure
       expect(account).toEqual(null);
 
-      // Validate isUEA flag
-      expect(isUEA).toBe(false);
+      // Validate exists flag
+      expect(exists).toBe(false);
     }, 30000); // 30 second timeout for network call
 
     it('Random Push Address WITHOUT transactions: should handle non-UEA addresses gracefully', async () => {
@@ -164,20 +167,20 @@ describe('Universal Account Utilities', () => {
       const testAddress =
         '0x0000000000000000000000000000000000000001' as `0x${string}`;
 
-      const result = await PushChain.utils.account.convertExecutorToOrigin(
-        testAddress
-      );
+      const result =
+        await PushChain.utils.account.convertExecutorToOriginAccount(
+          testAddress
+        );
 
-      const { account, isUEA } = result;
+      const { account, exists } = result;
 
       expect(account).toEqual(null);
 
-      expect(isUEA).toBe(false);
+      expect(exists).toBe(false);
 
-      // Validate the result structure - should be a tuple [account, isUEA]
+      // Validate the result structure - should be a object { account, exists }
       expect(result).toHaveProperty('account');
-      expect(result).toHaveProperty('isUEA');
-
+      expect(result).toHaveProperty('exists');
     }, 30000); // 30 second timeout for network call
   });
 

--- a/packages/core/src/lib/universal/account/account.ts
+++ b/packages/core/src/lib/universal/account/account.ts
@@ -12,7 +12,11 @@ import {
   VM_NAMESPACE,
 } from '../../constants/chain';
 import { CHAIN, VM, PUSH_NETWORK } from '../../constants/enums';
-import { UniversalAccount } from '../universal.types';
+import {
+  ExecutorAccountInfo,
+  OriginAccountInfo,
+  UniversalAccount,
+} from '../universal.types';
 import { utils } from '@coral-xyz/anchor';
 import { FACTORY_V1 } from '../../constants/abi';
 import { PushClient } from '../../push-client/push-client';
@@ -178,10 +182,7 @@ export async function convertOriginToExecutor(
   options: {
     onlyCompute?: boolean;
   } = { onlyCompute: true }
-): Promise<{
-  address: `0x${string}`;
-  deployed?: boolean;
-}> {
+): Promise<ExecutorAccountInfo> {
   const { chain, address } = account;
   const { vm, chainId } = CHAIN_INFO[chain];
 
@@ -280,9 +281,15 @@ export async function convertOriginToExecutor(
   return { address: computedAddress };
 }
 
-export async function convertExecutorToOrigin(
+/**
+ * Convert Executor to Origin Account
+ *
+ * Given a UEA (executor) address on Push Chain, returns the mapped origin
+ * account and an existence flag.
+ */
+export async function convertExecutorToOriginAccount(
   ueaAddress: `0x${string}`
-): Promise<{ account: UniversalAccount | null; isUEA: boolean }> {
+): Promise<OriginAccountInfo> {
   const RPC_URL = PUSH_CHAIN_INFO[CHAIN.PUSH_TESTNET_DONUT].defaultRPC[0];
   const FACTORY_ADDRESS =
     PUSH_CHAIN_INFO[CHAIN.PUSH_TESTNET_DONUT].factoryAddress;
@@ -309,7 +316,7 @@ export async function convertExecutorToOrigin(
     account.chainId === '' ||
     account.owner === '0x'
   ) {
-    return { account: null, isUEA };
+    return { account: null, exists: isUEA };
   }
 
   const universalAccount = PushChain.utils.account.fromChainAgnostic(
@@ -323,7 +330,7 @@ export async function convertExecutorToOrigin(
     }
   }
 
-  return { account: universalAccount, isUEA };
+  return { account: universalAccount, exists: isUEA };
 }
 
 function isPushChain(chain: CHAIN): boolean {

--- a/packages/core/src/lib/universal/universal.types.ts
+++ b/packages/core/src/lib/universal/universal.types.ts
@@ -123,3 +123,31 @@ export interface UniversalSignerSkeleton {
     message: Record<string, any>;
   }) => Promise<Uint8Array>;
 }
+
+/**
+ * Response model for converting an Executor (UEA) address to its Origin account.
+ */
+export interface OriginAccountInfo {
+  /**
+   * Resolved Origin account when the executor address maps to a known UEA; otherwise null.
+   */
+  account: UniversalAccount | null;
+  /**
+   * Whether the provided executor address corresponds to a Universal Executor Account (UEA).
+   */
+  exists: boolean;
+}
+
+/**
+ * Response model for converting an Origin account to its Executor (UEA) address.
+ */
+export interface ExecutorAccountInfo {
+  /**
+   * The computed or resolved UEA address on Push Chain.
+   */
+  address: `0x${string}`;
+  /**
+   * When computed with deployment check, indicates if the UEA is deployed on-chain.
+   */
+  deployed?: boolean;
+}

--- a/packages/core/src/lib/utils.ts
+++ b/packages/core/src/lib/utils.ts
@@ -1,7 +1,7 @@
 import {
   convertOriginToExecutor,
   fromChainAgnostic,
-  convertExecutorToOrigin,
+  convertExecutorToOriginAccount,
   toChainAgnostic,
   toUniversal,
 } from './universal/account';
@@ -59,7 +59,7 @@ export class Utils {
 
     convertOriginToExecutor,
 
-    convertExecutorToOrigin,
+    convertExecutorToOriginAccount,
   };
 
   static signer = {


### PR DESCRIPTION
- Renamed `convertExecutorToOrigin` to `convertExecutorToOriginAccount` for clarity.
- Updated return types to use new response models: `OriginAccountInfo` and `ExecutorAccountInfo`.
- Adjusted related tests to reflect changes in the utility function and response structure.