### PR TITLE
feat(core): archive-RPC fallback for prune-miss reads in tracking

### DIFF
--- a/packages/core/src/lib/constants/chain.ts
+++ b/packages/core/src/lib/constants/chain.ts
@@ -184,6 +184,10 @@ export const CHAIN_INFO: Record<
     lockerContract?: string;
     gatewayVersion?: 'v0' | 'v1'; // v0 = RevertInstructions struct, v1 = revertRecipient address
     defaultRPC: string[];
+    // Full-history (archive) EVM JSON-RPC, used as a fallback when the prune
+    // `defaultRPC` can't serve an older tx (a pruned-history miss). Unset for
+    // chains without a dedicated archive endpoint (fallback becomes a no-op).
+    archiveRPC?: string[];
     confirmations: number; // Confirmations required to mark a tx as finalized
     fastConfirmations: number; // Confirmations for GAS tx types (0, 1) - typically 0 for fast mode
     timeout: number; // Wait timeout in ms for required confirmations : Ideal value = (confirmations + 1)* Avg Chain Block time
@@ -210,6 +214,9 @@ export const CHAIN_INFO: Record<
     chainId: '42101',
     vm: VM.EVM,
     defaultRPC: ['https://evm.donut.rpc.push.org/'],
+    // Archive (full-history) EVM RPC — fallback for tracking older txs the
+    // prune `defaultRPC` has dropped.
+    archiveRPC: ['https://archive.evm.donut.rpc.push.org/'],
     confirmations: 1,
     fastConfirmations: 0,
     timeout: 30000,
@@ -361,6 +368,11 @@ export const PUSH_CHAIN_INFO: Record<
   (typeof CHAIN_INFO)[CHAIN.PUSH_MAINNET] & {
     denom: string;
     tendermintRpc: string[];
+    // Full-history (archive) Tendermint RPC, used as a fallback when the prune
+    // `tendermintRpc` can't serve an older tx (e.g. `tx_search` for a leg
+    // outside the prune window). Unset where there is no archive endpoint
+    // (fallback becomes a no-op).
+    archiveTendermintRpc?: string[];
     prefix: string;
     factoryAddress: `0x${string}`;
     pushDecimals: bigint;
@@ -384,6 +396,9 @@ export const PUSH_CHAIN_INFO: Record<
     ...CHAIN_INFO[CHAIN.PUSH_TESTNET_DONUT],
     denom: 'upc',
     tendermintRpc: ['https://donut.rpc.push.org/'],
+    // Archive (full-history) Tendermint RPC — fallback for tracking older txs
+    // whose legs fall outside the prune window.
+    archiveTendermintRpc: ['https://archive.donut.rpc.push.org/'],
     prefix: 'push',
     factoryAddress: '0x00000000000000000000000000000000000000eA',
     pushDecimals: BigInt(1e18),

--- a/packages/core/src/lib/orchestrator/internals/inbound-tracker.ts
+++ b/packages/core/src/lib/orchestrator/internals/inbound-tracker.ts
@@ -331,9 +331,12 @@ export async function waitForInboundPushTx(
           // chain, treat as terminal-success; if it reverted, treat as
           // terminal-failure. Cosmos-indexer lag stops blocking us here.
           try {
-            const receipt = await ctx.pushClient.publicClient.getTransactionReceipt({
-              hash: pushTxHash as `0x${string}`,
-            });
+            // Archive-fallback variant: a Push-leg receipt outside the prune
+            // window still resolves via the archive node. On chains without an
+            // archive endpoint this behaves as a plain prune-only lookup.
+            const receipt = await ctx.pushClient.getTransactionReceiptWithArchiveFallback(
+              pushTxHash as `0x${string}`
+            );
             if (receipt?.status === 'success') {
               printLog(
                 ctx,

--- a/packages/core/src/lib/push-client/push-client.archive-fallback.spec.ts
+++ b/packages/core/src/lib/push-client/push-client.archive-fallback.spec.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for PushClient's prune-first → archive-fallback.
+ *
+ * The fallback is the explicit "prune returned empty/not-found → re-query
+ * archive" logic that the per-URL transport machinery can't do on its own
+ * (a pruned tx comes back as a *successful* empty result, not a transport
+ * error). It is always on, and inert for chains without an archive endpoint
+ * configured (mainnet/localnet). These tests mock the Cosmos transport so
+ * they're network-free and assert: (1) an empty prune result triggers an
+ * archive re-query that wins, (2) a non-empty prune result short-circuits
+ * (archive untouched), and (3) a chain with no archive endpoint never
+ * consults archive.
+ */
+import { StargateClient } from '@cosmjs/stargate';
+import { PushClient } from './push-client';
+import { PUSH_CHAIN_INFO } from '../constants/chain';
+import { CHAIN, PUSH_NETWORK } from '../constants/enums';
+
+// Mock only StargateClient.connect; keep the rest of @cosmjs/stargate real
+// (PushClient also imports QueryClient/createProtobufRpcClient/etc from it).
+jest.mock('@cosmjs/stargate', () => {
+  const actual = jest.requireActual('@cosmjs/stargate');
+  return { ...actual, StargateClient: { connect: jest.fn() } };
+});
+
+const connectMock = StargateClient.connect as unknown as jest.Mock;
+
+const PRUNE_TM = PUSH_CHAIN_INFO[CHAIN.PUSH_TESTNET_DONUT].tendermintRpc[0];
+const ARCHIVE_TM =
+  PUSH_CHAIN_INFO[CHAIN.PUSH_TESTNET_DONUT].archiveTendermintRpc![0];
+
+const isArchiveUrl = (url: string) => url.includes('archive');
+
+// A minimal, JSON-serializable indexed-tx stand-in.
+const HIT = { height: 123, hash: 'DEADBEEF', events: [] };
+
+// Donut has archive endpoints → fallback active.
+const donutClient = () =>
+  new PushClient({
+    rpcUrls: PUSH_CHAIN_INFO[CHAIN.PUSH_TESTNET_DONUT].defaultRPC,
+    network: PUSH_NETWORK.TESTNET_DONUT,
+  });
+
+// Localnet has NO archive endpoints → fallback inert (prune-only).
+const localnetClient = () =>
+  new PushClient({
+    rpcUrls: PUSH_CHAIN_INFO[CHAIN.PUSH_LOCALNET].defaultRPC,
+    network: PUSH_NETWORK.LOCALNET,
+  });
+
+beforeEach(() => {
+  connectMock.mockReset();
+});
+
+describe('PushClient archive fallback — searchCosmosByQuery', () => {
+  it('re-queries archive when prune returns empty, and returns the archive hit', async () => {
+    // prune → [], archive → [HIT]
+    connectMock.mockImplementation(async (url: string) => ({
+      searchTx: async () => (isArchiveUrl(url) ? [HIT] : []),
+    }));
+
+    const results = await donutClient().searchCosmosByQuery("foo='bar'");
+
+    expect(results).toHaveLength(1);
+    const urls = connectMock.mock.calls.map((c) => c[0]);
+    expect(urls).toContain(PRUNE_TM);
+    expect(urls).toContain(ARCHIVE_TM);
+    // prune is consulted before archive
+    expect(urls.indexOf(PRUNE_TM)).toBeLessThan(urls.indexOf(ARCHIVE_TM));
+  });
+
+  it('does NOT touch archive when prune already has a result', async () => {
+    connectMock.mockImplementation(async () => ({
+      searchTx: async () => [HIT],
+    }));
+
+    const results = await donutClient().searchCosmosByQuery("foo='bar'");
+
+    expect(results).toHaveLength(1);
+    const urls = connectMock.mock.calls.map((c) => c[0]);
+    expect(urls.some(isArchiveUrl)).toBe(false);
+  });
+
+  it('chain without an archive endpoint never consults archive (inert)', async () => {
+    connectMock.mockImplementation(async (url: string) => ({
+      searchTx: async () => (isArchiveUrl(url) ? [HIT] : []),
+    }));
+
+    const results = await localnetClient().searchCosmosByQuery("foo='bar'");
+
+    expect(results).toHaveLength(0); // prune-only empty, no archive rescue
+    const urls = connectMock.mock.calls.map((c) => c[0]);
+    expect(urls.some(isArchiveUrl)).toBe(false);
+  });
+});
+
+describe('PushClient archive fallback — getCosmosTx', () => {
+  it('falls back to archive when prune has no indexed tx (op throws on empty)', async () => {
+    const txHash = '0xabc';
+    connectMock.mockImplementation(async (url: string) => ({
+      searchTx: async () =>
+        isArchiveUrl(url) ? [{ ...HIT }] : [], // prune empty → op throws → archive
+    }));
+
+    const tx = await donutClient().getCosmosTx(txHash);
+
+    expect(tx.transactionHash).toBe(txHash);
+    const urls = connectMock.mock.calls.map((c) => c[0]);
+    expect(urls.some(isArchiveUrl)).toBe(true);
+  });
+
+  it('chain without an archive endpoint throws when prune has no indexed tx', async () => {
+    connectMock.mockImplementation(async () => ({
+      searchTx: async () => [],
+    }));
+
+    await expect(localnetClient().getCosmosTx('0xabc')).rejects.toThrow();
+    const urls = connectMock.mock.calls.map((c) => c[0]);
+    expect(urls.some(isArchiveUrl)).toBe(false);
+  });
+});

--- a/packages/core/src/lib/push-client/push-client.ts
+++ b/packages/core/src/lib/push-client/push-client.ts
@@ -1,4 +1,12 @@
-import { hexToBytes, keccak256 } from 'viem';
+import {
+  createPublicClient,
+  fallback,
+  hexToBytes,
+  http,
+  keccak256,
+  PublicClient,
+  TransactionReceipt,
+} from 'viem';
 import { MsgDeployUEA, MsgExecutePayload, MsgMintPC, MsgMigrateUEA } from '../generated/v1/tx';
 import { Any } from 'cosmjs-types/google/protobuf/any';
 import { SignDoc, TxBody, TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx';
@@ -25,7 +33,8 @@ import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 import { toBech32 } from '@cosmjs/encoding';
 import { EvmClient } from '../vm-client/evm-client';
 import { PushClientOptions } from './push-client.types';
-import { getPushViemChain, PUSH_CHAIN_INFO } from '../constants/chain';
+import { TxResponse } from '../vm-client/vm-client.types';
+import { CHAIN_INFO, getPushViemChain, PUSH_CHAIN_INFO } from '../constants/chain';
 import { CHAIN, PUSH_NETWORK } from '../constants/enums';
 
 function pushNetworkToChain(
@@ -48,14 +57,41 @@ export class PushClient extends EvmClient {
   private readonly ephemeralKey;
   private readonly ephemeralAccount;
   private currentRpcIndex = 0;
+
+  /**
+   * Archive (full-history) endpoints. History-sensitive reads fall back from
+   * the prune RPC to these on a pruned-history miss. Resolved from the chain's
+   * configured archive endpoints — empty/undefined for chains without one
+   * (mainnet/localnet), where the fallback is a no-op (prune-only behaviour).
+   */
+  private readonly archiveTendermintRpc: string[];
+  private readonly archivePublicClient?: PublicClient;
+
   constructor(clientOptions: PushClientOptions) {
     const pushChainKey = pushNetworkToChain(clientOptions.network);
+    const chain = clientOptions.chain ?? getPushViemChain(pushChainKey);
     super({
       ...clientOptions,
-      chain: clientOptions.chain ?? getPushViemChain(pushChainKey),
+      chain,
     });
 
     this.pushChainInfo = PUSH_CHAIN_INFO[pushChainKey];
+
+    // Archive fallback is always set up; it's inert for chains without an
+    // archive endpoint (mainnet/localnet → empty lists), and otherwise lets
+    // history-sensitive reads recover a pruned tx from the archive node.
+    this.archiveTendermintRpc = this.pushChainInfo.archiveTendermintRpc ?? [];
+    const archiveEvmUrls = CHAIN_INFO[pushChainKey].archiveRPC ?? [];
+    if (archiveEvmUrls.length > 0) {
+      this.archivePublicClient = createPublicClient({
+        chain,
+        transport: fallback(
+          archiveEvmUrls.map((url) =>
+            http(url, { retryCount: 5, retryDelay: 500 })
+          )
+        ),
+      });
+    }
 
     this.ephemeralKey = generatePrivateKey();
     this.ephemeralAccount = privateKeyToAccount(this.ephemeralKey);
@@ -67,9 +103,13 @@ export class PushClient extends EvmClient {
    */
   private async executeWithRpcFallback<T>(
     operation: (rpcUrl: string) => Promise<T>,
-    operationName = 'operation'
+    operationName = 'operation',
+    rpcUrls: string[] = this.pushChainInfo.tendermintRpc,
+    // Sticky cursor (`currentRpcIndex`) is only meaningful for the primary
+    // prune pool; the archive pass passes `sticky=false` so a single archive
+    // URL can't pin the prune cursor.
+    sticky = true
   ): Promise<T> {
-    const rpcUrls = this.pushChainInfo.tendermintRpc;
     let lastError: Error | null = null;
 
     // Cycle the RPC URLs, but also RETRY transient failures (5xx / network /
@@ -94,12 +134,13 @@ export class PushClient extends EvmClient {
     };
 
     for (let attempt = 0; attempt < totalAttempts; attempt++) {
-      const rpcIndex = (this.currentRpcIndex + attempt) % rpcUrls.length;
+      const baseIndex = sticky ? this.currentRpcIndex : 0;
+      const rpcIndex = (baseIndex + attempt) % rpcUrls.length;
       const rpcUrl = rpcUrls[rpcIndex];
 
       try {
         const result = await operation(rpcUrl);
-        if (rpcIndex !== this.currentRpcIndex) {
+        if (sticky && rpcIndex !== this.currentRpcIndex) {
           this.currentRpcIndex = rpcIndex;
         }
         return result;
@@ -121,6 +162,57 @@ export class PushClient extends EvmClient {
     throw new Error(
       `All RPC endpoints failed for ${operationName}. Last error: ${lastError?.message}`
     );
+  }
+
+  /**
+   * Runs a history-sensitive Tendermint operation over the prune pool first and,
+   * only when prune can't serve it (the op threw on all prune attempts, or
+   * returned an `isEmpty` result), re-queries the archive pool. This is the
+   * explicit "prune miss → archive" fallback the existing per-URL machinery
+   * can't do on its own, because a pruned tx comes back as a *successful*
+   * empty/not-found rather than a transport error.
+   *
+   * When no archive is configured (mainnet/localnet, or `enableArchiveFallback`
+   * off) this is a pass-through: the original throw or empty result is returned
+   * unchanged — behaviour identical to before.
+   */
+  private async executeWithArchiveFallback<T>(
+    operation: (rpcUrl: string) => Promise<T>,
+    operationName: string,
+    isEmpty: (result: T) => boolean
+  ): Promise<T> {
+    let pruneResult: T | undefined;
+    let pruneError: unknown;
+    try {
+      pruneResult = await this.executeWithRpcFallback(operation, operationName);
+    } catch (error) {
+      pruneError = error;
+    }
+
+    const pruneMissed =
+      pruneError !== undefined ||
+      (pruneResult !== undefined && isEmpty(pruneResult));
+
+    if (!pruneMissed) {
+      return pruneResult as T;
+    }
+    if (this.archiveTendermintRpc.length === 0) {
+      // No archive: preserve original behaviour (re-throw, or return empty).
+      if (pruneError !== undefined) throw pruneError;
+      return pruneResult as T;
+    }
+    // Prune missed + archive available → re-query archive (non-sticky).
+    return this.executeWithRpcFallback(
+      operation,
+      `${operationName} (archive)`,
+      this.archiveTendermintRpc,
+      false
+    );
+  }
+
+  /** True when this client has a usable archive EVM endpoint configured. */
+  private get hasArchiveEvm(): boolean {
+    return this.archivePublicClient !== undefined;
   }
 
   /**
@@ -305,7 +397,7 @@ export class PushClient extends EvmClient {
   public async getUniversalTxByIdV2(
     id: string
   ): Promise<QueryGetUniversalTxResponseV2> {
-    return this.executeWithRpcFallback(async (rpcUrl) => {
+    const operation = async (rpcUrl: string) => {
       const tmClient = await Tendermint34Client.connect(rpcUrl);
       const queryClient = new QueryClient(tmClient);
       const rpc = createProtobufRpcClient(queryClient);
@@ -317,7 +409,22 @@ export class PushClient extends EvmClient {
         QueryGetUniversalTxRequestV2.encode(request).finish()
       );
       return QueryGetUniversalTxResponseV2.decode(responseBytes);
-    }, 'getUniversalTxByIdV2');
+    };
+    // This is a current-STATE query (abci_query), so prune is always
+    // authoritative — an empty `universalTx` is a real "doesn't exist", not a
+    // pruned-history miss. Only fall back to archive on a hard error (all prune
+    // attempts failed); never on an empty result (would double-load on polls).
+    try {
+      return await this.executeWithRpcFallback(operation, 'getUniversalTxByIdV2');
+    } catch (error) {
+      if (this.archiveTendermintRpc.length === 0) throw error;
+      return this.executeWithRpcFallback(
+        operation,
+        'getUniversalTxByIdV2 (archive)',
+        this.archiveTendermintRpc,
+        false
+      );
+    }
   }
 
   /**
@@ -328,7 +435,7 @@ export class PushClient extends EvmClient {
   public async searchCosmosByQuery(
     query: string
   ): Promise<DeliverTxResponse[]> {
-    return this.executeWithRpcFallback(async (rpcUrl) => {
+    const operation = async (rpcUrl: string) => {
       const client = await StargateClient.connect(rpcUrl);
       const results = await client.searchTx(query);
       return results.map((result) =>
@@ -337,8 +444,15 @@ export class PushClient extends EvmClient {
             typeof value === 'bigint' ? value.toString() : value
           )
         )
-      );
-    }, 'searchCosmosByQuery');
+      ) as DeliverTxResponse[];
+    };
+    // History-sensitive (tx_search): an empty result on prune may just mean the
+    // matching tx is outside the prune window → retry archive.
+    return this.executeWithArchiveFallback(
+      operation,
+      'searchCosmosByQuery',
+      (results) => results.length === 0
+    );
   }
 
   /**
@@ -348,7 +462,7 @@ export class PushClient extends EvmClient {
    * @throws If the tx isn't found.
    */
   public async getCosmosTx(txHash: string): Promise<DeliverTxResponse> {
-    return this.executeWithRpcFallback(async (rpcUrl) => {
+    const operation = async (rpcUrl: string): Promise<DeliverTxResponse> => {
       const client = await StargateClient.connect(rpcUrl);
 
       const query = `ethereum_tx.ethereumTxHash='${txHash}'`;
@@ -370,6 +484,48 @@ export class PushClient extends EvmClient {
         throw new Error(`No Cosmos-indexed tx for EVM hash ${txHash}`);
       }
       return { ...convertedResults[0], transactionHash: txHash };
-    }, 'getCosmosTx');
+    };
+    // History-sensitive (tx_search). The op throws on an empty result, so the
+    // pruned-history miss surfaces as a thrown error — `isEmpty` stays false and
+    // the wrapper retries archive via its caught-error path.
+    return this.executeWithArchiveFallback(operation, 'getCosmosTx', () => false);
+  }
+
+  /**
+   * EVM `getTransaction` with archive fallback. Prune first; on a not-found
+   * (pruned, or not yet indexed) and an archive EVM endpoint configured, retry
+   * the archive client. Without archive this is exactly `super.getTransaction`.
+   */
+  public override async getTransaction(
+    txHash: `0x${string}`
+  ): Promise<TxResponse> {
+    try {
+      return await super.getTransaction(txHash);
+    } catch (error) {
+      if (!this.hasArchiveEvm) throw error;
+      const archiveClient = this.archivePublicClient as PublicClient;
+      const tx = await archiveClient.getTransaction({ hash: txHash });
+      const wait = async (confirmations = 1): Promise<TransactionReceipt> =>
+        archiveClient.waitForTransactionReceipt({ hash: txHash, confirmations });
+      return { ...tx, wait };
+    }
+  }
+
+  /**
+   * EVM `getTransactionReceipt` with archive fallback. Used by the inbound
+   * tracker to fetch a Push-leg receipt that may predate the prune window.
+   * Prune first; on not-found, retry the archive EVM client if configured.
+   */
+  public async getTransactionReceiptWithArchiveFallback(
+    txHash: `0x${string}`
+  ): Promise<TransactionReceipt> {
+    try {
+      return await this.publicClient.getTransactionReceipt({ hash: txHash });
+    } catch (error) {
+      if (!this.hasArchiveEvm) throw error;
+      return (this.archivePublicClient as PublicClient).getTransactionReceipt({
+        hash: txHash,
+      });
+    }
   }
 }


### PR DESCRIPTION
The public RPC LB now serves prune-only (~100k blocks), so trackTransaction and its .wait() can't read txs older than the prune window. Add a prune-first → archive-fallback in PushClient: history-sensitive reads query prune first and, only on an empty/not-found result, re-query the chain's archive endpoint.

Neither viem's fallback() nor executeWithRpcFallback fails over on a pruned miss (both treat not-found as a successful empty result), so the fallback is an explicit re-query: getCosmosTx/searchCosmosByQuery via executeWithArchive Fallback, an EVM getTransaction override, and getTransactionReceiptWith ArchiveFallback (used by the inbound tracker). getUniversalTxByIdV2 only falls back on a hard error since it's a current-state query, not history.

Archive endpoints live in constants (CHAIN_INFO.archiveRPC, PUSH_CHAIN_INFO.archiveTendermintRpc) and are Donut-only; the fallback is always on and inert for chains without an archive endpoint (mainnet/localnet).

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] This PR does not contain plagiarized content.
- [ ] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
