### PR TITLE
feat(core): native EIP-7702 atomic multicall for native-Push EOAs

### DIFF
--- a/packages/core/__e2e__/scripts/e2e-7702-multicall.ts
+++ b/packages/core/__e2e__/scripts/e2e-7702-multicall.ts
@@ -107,6 +107,8 @@ async function main() {
     data: calls,
   });
   console.log(`tx hash: ${tx.hash}`);
+  console.log(`tx.atomic: ${tx.atomic}`);
+  assert(tx.atomic === true, 'response reports atomic === true for the 7702 batch');
   const receipt = await tx.wait();
   console.log(`receipt status: ${receipt.status}`);
   assert(receipt.status === 1, 'transaction succeeded');
@@ -136,6 +138,38 @@ async function main() {
     (code ?? '').toLowerCase() === expectedDesignator,
     'EOA delegated to PushBatchExecutor (0xef0100 ‖ executor)'
   );
+
+  // --------------------------------------------------------------------
+  // Fallback scenario: a signer WITHOUT 7702 capability must take the
+  // sequential per-call loop and report atomic === false.
+  // --------------------------------------------------------------------
+  console.log('\nForcing the non-7702 sequential fallback...');
+  const fallbackSigner = await PushChain.utils.signer.toUniversalFromKeypair(
+    walletClient,
+    {
+      chain: CHAIN.PUSH_TESTNET_DONUT,
+      library: PushChain.CONSTANTS.LIBRARY.ETHEREUM_VIEM,
+    }
+  );
+  // Strip the capability so sendPushTx cannot use EIP-7702.
+  delete (fallbackSigner as { signAuthorization?: unknown }).signAuthorization;
+  assert(
+    fallbackSigner.signAuthorization === undefined,
+    'fallback signer has no signAuthorization'
+  );
+  const fallbackClient = await PushChain.initialize(fallbackSigner, {
+    network: PushChain.CONSTANTS.PUSH_NETWORK.TESTNET_DONUT,
+  });
+  const fbTx = await fallbackClient.universal.sendTransaction({
+    to: COUNTER_ADDRESS_PAYABLE,
+    data: Array.from({ length: 2 }, () => ({
+      to: COUNTER_ADDRESS_PAYABLE,
+      value: BigInt(0),
+      data: incrementData,
+    })),
+  });
+  console.log(`fallback tx.atomic: ${fbTx.atomic}`);
+  assert(fbTx.atomic === false, 'sequential fallback reports atomic === false');
 
   console.log('\n🎉 e2e 7702 multicall passed');
 }

--- a/packages/core/__e2e__/scripts/e2e-7702-multicall.ts
+++ b/packages/core/__e2e__/scripts/e2e-7702-multicall.ts
@@ -1,0 +1,146 @@
+/**
+ * Standalone e2e: native-Push EIP-7702 atomic multicall.
+ *
+ * Drives the real SDK path (sendPushTx → EvmClient.sendBatch7702) against Push
+ * testnet + the deployed PushBatchExecutor. Sends 3 increments in one type-4 tx
+ * and asserts the counter advanced by exactly 3, the tx was type-4, and the EOA
+ * carries the 7702 delegation designator.
+ *
+ * Run from packages/core (ts-node is the runner available in this workspace):
+ *   ../../node_modules/.bin/ts-node --transpile-only \
+ *     --compiler-options '{"module":"commonjs","moduleResolution":"node","esModuleInterop":true,"resolveJsonModule":true}' \
+ *     __e2e__/scripts/e2e-7702-multicall.ts
+ */
+import 'dotenv/config';
+import {
+  createPublicClient,
+  createWalletClient,
+  defineChain,
+  http,
+} from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { PushChain } from '../../src';
+import { CHAIN } from '../../src/lib/constants/enums';
+import {
+  PUSH_BATCH_EXECUTOR_ADDRESS,
+  getBatchExecutorAddress,
+} from '../../src/lib/constants/chain';
+import { COUNTER_ADDRESS_PAYABLE } from '../../src/lib/push-chain/helpers/addresses';
+import { COUNTER_ABI_PAYABLE } from '../../src/lib/push-chain/helpers/abis';
+
+const RPC = 'https://evm.donut.rpc.push.org/';
+
+const pushDonut = defineChain({
+  id: 42101,
+  name: 'Push Donut Testnet',
+  nativeCurrency: { name: 'Push', symbol: 'PC', decimals: 18 },
+  rpcUrls: { default: { http: [RPC] } },
+});
+
+function assert(cond: boolean, msg: string) {
+  if (!cond) {
+    console.error(`❌ ASSERT FAILED: ${msg}`);
+    process.exit(1);
+  }
+  console.log(`✅ ${msg}`);
+}
+
+async function main() {
+  const pk = (process.env['PUSH_PRIVATE_KEY'] ||
+    process.env['EVM_PRIVATE_KEY']) as `0x${string}`;
+  if (!pk) throw new Error('PUSH_PRIVATE_KEY / EVM_PRIVATE_KEY not set');
+
+  const account = privateKeyToAccount(pk);
+  console.log(`Signer EOA: ${account.address}`);
+  console.log(
+    `Configured executor: ${getBatchExecutorAddress(CHAIN.PUSH_TESTNET_DONUT)}`
+  );
+
+  const walletClient = createWalletClient({
+    account,
+    chain: pushDonut,
+    transport: http(RPC),
+  });
+  const publicClient = createPublicClient({ chain: pushDonut, transport: http(RPC) });
+
+  const signer = await PushChain.utils.signer.toUniversalFromKeypair(
+    walletClient,
+    {
+      chain: CHAIN.PUSH_TESTNET_DONUT,
+      library: PushChain.CONSTANTS.LIBRARY.ETHEREUM_VIEM,
+    }
+  );
+  assert(
+    typeof signer.signAuthorization === 'function',
+    'signer exposes signAuthorization (7702-capable)'
+  );
+
+  const client = await PushChain.initialize(signer, {
+    network: PushChain.CONSTANTS.PUSH_NETWORK.TESTNET_DONUT,
+  });
+
+  const readCount = () =>
+    publicClient.readContract({
+      address: COUNTER_ADDRESS_PAYABLE,
+      abi: COUNTER_ABI_PAYABLE as never,
+      functionName: 'countPC',
+    }) as Promise<bigint>;
+
+  const before = await readCount();
+  console.log(`countPC before: ${before}`);
+
+  const incrementData = PushChain.utils.helpers.encodeTxData({
+    abi: COUNTER_ABI_PAYABLE as unknown as any[],
+    functionName: 'increment',
+  }) as `0x${string}`;
+
+  const N = 3;
+  const calls = Array.from({ length: N }, () => ({
+    to: COUNTER_ADDRESS_PAYABLE,
+    value: BigInt(0),
+    data: incrementData,
+  }));
+
+  console.log(`\nSending ${N}-call multicall via native EIP-7702...`);
+  const tx = await client.universal.sendTransaction({
+    to: COUNTER_ADDRESS_PAYABLE,
+    data: calls,
+  });
+  console.log(`tx hash: ${tx.hash}`);
+  const receipt = await tx.wait();
+  console.log(`receipt status: ${receipt.status}`);
+  assert(receipt.status === 1, 'transaction succeeded');
+
+  // Inspect the on-chain tx type — must be eip7702 (type 4).
+  const onchain = await publicClient.getTransaction({
+    hash: tx.hash as `0x${string}`,
+  });
+  console.log(`tx type: ${onchain.type}`);
+  assert(onchain.type === 'eip7702', 'tx is a single type-4 (eip7702) transaction');
+
+  const after = await readCount();
+  console.log(`countPC after: ${after}`);
+  assert(
+    after === before + BigInt(N),
+    `counter advanced by exactly ${N} atomically (${before} → ${after})`
+  );
+
+  // EOA should now carry the 7702 delegation designator: 0xef0100 || executor.
+  const code = await publicClient.getCode({ address: account.address });
+  const expectedExecutor = PUSH_BATCH_EXECUTOR_ADDRESS[CHAIN.PUSH_TESTNET_DONUT]!;
+  const expectedDesignator = (
+    '0xef0100' + expectedExecutor.slice(2)
+  ).toLowerCase();
+  console.log(`EOA code: ${code}`);
+  assert(
+    (code ?? '').toLowerCase() === expectedDesignator,
+    'EOA delegated to PushBatchExecutor (0xef0100 ‖ executor)'
+  );
+
+  console.log('\n🎉 e2e 7702 multicall passed');
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/core/docs/native-7702-batching-summary.md
+++ b/packages/core/docs/native-7702-batching-summary.md
@@ -46,6 +46,21 @@ If the wallet can't sign a 7702 authorization, the SDK falls back to the legacy
 sequential loop (+ `console.warn`). The fallback only triggers **before any tx is
 broadcast**, so it can never double-execute. Real reverts are surfaced, not hidden.
 
+## Knowing which path ran (`atomic`)
+
+The tx response now has an `atomic: boolean` (after `type`/`typeVerbose`): `true`
+for a single tx, a 7702 batch, or a UEA multicall; `false` only for the native
+sequential fallback. Check it when atomicity matters (`atomic === false` ⇒ the
+batch may have partially applied).
+
+## Gas abstraction
+
+Sponsor-pays batch execution is delivered by the **existing UEA path**, not
+native 7702: an **external-origin** user's batch runs on their UEA via a zero-fee
+Cosmos message (chain-sponsored, atomic) — already automatic. A **native-Push
+EOA has no UEA**, so it executes self-paid (7702 or fallback); true sponsor-pays
+for a raw EOA would need new infra (out of scope).
+
 ## Where the code lives
 
 - Contract (canonical): `push-chain-core-contracts/src/executor/PushBatchExecutor.sol`

--- a/packages/core/docs/native-7702-batching-summary.md
+++ b/packages/core/docs/native-7702-batching-summary.md
@@ -12,14 +12,15 @@ the native-Push route.
 - **Before:** 3 calls → 3 txs. If call 2 reverts, call 1 stays committed.
 - **After:** 3 calls → 1 tx. All succeed or all revert.
 
-How: the EOA delegates its code to a `PushBatchExecutor` contract via a type-4
-(`SetCode`) tx and calls `execute(calls)` on itself in the same tx.
+How: the EOA delegates its code to a `PushBatchExecutor` contract (a thin wrapper
+over OpenZeppelin's **ERC-7821** implementation, `draft-ERC7821`) via a type-4 (`SetCode`)
+tx and calls `execute(mode, executionData)` on itself in the same tx.
 
 ## Status: ✅ live on Testnet Donut
 
 | | |
 | --- | --- |
-| Executor | `0x776d8031b9caA053d04325Bc2CAc47E5cb673776` (chain 42101) |
+| Executor | `0x0106BF2F9B02f32203A83a3bDaD79fE8818f3796` (chain 42101, OZ ERC-7821) |
 | Verified | e2e on testnet — 3 calls, 1 type-4 tx, counter +3 atomic |
 | Mainnet | not live yet — nothing to deploy |
 

--- a/packages/core/docs/native-7702-batching-summary.md
+++ b/packages/core/docs/native-7702-batching-summary.md
@@ -1,0 +1,54 @@
+# Native EIP-7702 Multicall — Summary
+
+_Short version for sharing. Full details: [`native-7702-batching.md`](./native-7702-batching.md)._
+
+## What changed
+
+Native-Push EOA multicalls now run as **one atomic EIP-7702 transaction** instead
+of N separate, non-atomic transactions. Same SDK API
+(`universal.sendTransaction({ to, data: calls })`) — the upgrade is automatic on
+the native-Push route.
+
+- **Before:** 3 calls → 3 txs. If call 2 reverts, call 1 stays committed.
+- **After:** 3 calls → 1 tx. All succeed or all revert.
+
+How: the EOA delegates its code to a `PushBatchExecutor` contract via a type-4
+(`SetCode`) tx and calls `execute(calls)` on itself in the same tx.
+
+## Status: ✅ live on Testnet Donut
+
+| | |
+| --- | --- |
+| Executor | `0x776d8031b9caA053d04325Bc2CAc47E5cb673776` (chain 42101) |
+| Verified | e2e on testnet — 3 calls, 1 type-4 tx, counter +3 atomic |
+| Mainnet | not live yet — nothing to deploy |
+
+## Which multicalls use it?
+
+Only the **native-Push EOA** route, on a chain with a deployed executor, with a
+7702-capable wallet (local viem account / ethers v6). Everything else is unchanged:
+
+| Scenario | Path |
+| --- | --- |
+| Native Push EOA · testnet · capable wallet | ✅ 7702 atomic tx |
+| Native Push EOA · incapable wallet (injected/JSON-RPC) | ↩ legacy loop + warn |
+| Bridged / cross-chain (Ethereum, Base, …) | UEA proxy `UEA_MULTICALL` (already atomic) |
+| SVM / Solana | UEA `UEA_MULTICALL` (can't 7702) |
+| Outbound CEA batches | custom multicall (unchanged) |
+
+> The big bucket — bridged/cross-chain — was already atomic via the UEA proxy and
+> is untouched. 7702 only fixed the one route that wasn't atomic.
+
+## Fallback (safe by design)
+
+If the wallet can't sign a 7702 authorization, the SDK falls back to the legacy
+sequential loop (+ `console.warn`). The fallback only triggers **before any tx is
+broadcast**, so it can never double-execute. Real reverts are surfaced, not hidden.
+
+## Where the code lives
+
+- Contract (canonical): `push-chain-core-contracts/src/executor/PushBatchExecutor.sol`
+- Contract (vendored ref in SDK): `packages/core/src/lib/push-chain/helpers/PushBatchExecutor.sol`
+- SDK builder: `EvmClient.sendBatch7702` (`vm-client/evm-client.ts`)
+- Route branch: `sendPushTx` (`orchestrator/internals/push-chain-tx.ts`)
+- Address config: `PUSH_BATCH_EXECUTOR_ADDRESS` (`constants/chain.ts`)

--- a/packages/core/docs/native-7702-batching.md
+++ b/packages/core/docs/native-7702-batching.md
@@ -280,6 +280,49 @@ value, so large batches don't out-of-gas relative to the old per-call loop.
 
 ---
 
+## The `atomic` field on the response
+
+`UniversalTxResponse` carries an `atomic: boolean` (right after `type` /
+`typeVerbose`) so callers can tell whether a batch ran all-or-nothing:
+
+| Execution path | `atomic` |
+| --- | --- |
+| Single tx | `true` |
+| EIP-7702 batch (native, this feature) | `true` |
+| UEA `UEA_MULTICALL` (bridged / cross-chain / SVM) | `true` |
+| Outbound / funds / fee-lock | `true` |
+| **Native sequential fallback loop** | **`false`** |
+
+Implementation is default-`true` in `transformToUniversalTxResponse`
+(`response-builder.ts`), overridden to `false` only at the sequential-loop return
+in `sendPushTx` (`push-chain-tx.ts`). Use it when atomicity is load-bearing —
+e.g. treat `atomic === false` as "this batch may have partially applied."
+(Historical `trackTransaction` lookups keep the `true` default, since past
+execution mode isn't always recoverable.)
+
+## Gas abstraction
+
+Gas-abstracted (sponsor/relayer-pays) batch execution is **not a native-7702
+feature** — it's provided by the **existing UEA path** and applies to
+**external-origin** flows:
+
+- An **external-origin** user's batch is executed on their **UEA** via a zero-fee
+  Cosmos `MsgExecutePayload` that the node's `uexecutor` module runs
+  (`UEA_MULTICALL`, atomic). Submission is chain-sponsored (Cosmos `feegrant`);
+  the UEA funds EVM gas from its balance / cross-chain fee-lock. This path already
+  reports `atomic: true`.
+- A **native-Push EOA has no UEA**, so it cannot use this path — it executes
+  self-paid via the EIP-7702 batch (or the sequential fallback). There is no
+  `gasless` opt-in for native origins because there is nothing to route them
+  through; true sponsor-pays-gas for a raw EOA would require new infra (a
+  signature-authorized executor + relayer, or node-level type-4 fee sponsorship),
+  which is out of scope.
+
+Net: external-origin callers already get gasless + atomic batching automatically;
+native callers get atomic (7702) but self-paid.
+
+---
+
 ## Deployment
 
 | Network | Address | Notes |

--- a/packages/core/docs/native-7702-batching.md
+++ b/packages/core/docs/native-7702-batching.md
@@ -1,7 +1,9 @@
 # Native EIP-7702 Batching for Push Chain Multicalls
 
-> Status: **live on Push testnet (Donut).** `PushBatchExecutor` is deployed at
-> `0x776d8031b9caA053d04325Bc2CAc47E5cb673776` (chain 42101) and wired into the
+> Status: **live on Push testnet (Donut).** `PushBatchExecutor` — a thin wrapper
+> over OpenZeppelin's **ERC-7821** batch-executor implementation
+> (`draft-ERC7821`) — is deployed at
+> `0x0106BF2F9B02f32203A83a3bDaD79fE8818f3796` (chain 42101) and wired into the
 > SDK; the native-Push multicall path now produces a single atomic type-4 tx.
 > Verified end-to-end (see "Verification status"). Push mainnet isn't live yet,
 > so there's no mainnet deployment.
@@ -129,7 +131,7 @@ client.universal.sendTransaction({ to, data: [call1, call2, call3] })
    ┌─────────────────────────────────────────────────────────────────┐
    │ 1. sign 7702 authorization (EOA key):                            │
    │      { chainId, address: EXECUTOR, nonce: n+1, r, s, yParity }    │
-   │ 2. data = PushBatchExecutor.execute([call1, call2, call3])       │
+   │ 2. data = execute(batchMode, abi.encode([call1,call2,call3]))    │
    │ 3. serialize ONE type-4 (eip7702) tx:                            │
    │      to = EOA (self), nonce = n, authorizationList = [auth]       │
    └─────────────────────────────────────────────────────────────────┘
@@ -137,7 +139,7 @@ client.universal.sendTransaction({ to, data: [call1, call2, call3] })
         ▼
    ┌──────────────────── single transaction (atomic) ─────────────────┐
    │ ① node applies authorization: EOA.code ← 0xef0100 ‖ EXECUTOR      │
-   │ ② tx calls EOA.execute([calls]); msg.sender == address(this)      │
+   │ ② tx calls EOA.execute(mode, executionData); msg.sender==self     │
    │      → executor's self-call check passes (no per-call sig)        │
    │      ├─ call1 ✅  ├─ call2 ❌ revert  → WHOLE TX REVERTS           │
    │      └─ call1 rolled back                                         │
@@ -165,25 +167,33 @@ Two subtleties worth noting:
 
 ### Contract — `push-chain-core-contracts`
 
-**`src/executor/PushBatchExecutor.sol`** (new) — the EIP-7702 delegation target.
+**`src/executor/PushBatchExecutor.sol`** — the EIP-7702 delegation target, a thin
+wrapper over OpenZeppelin's **ERC-7821** minimal batch-executor implementation
+(OZ ships it as `draft-ERC7821`; ERC-7821 is still a draft EIP):
 
-- `execute(Multicall[] calls)` — **self-sponsored** path. Requires
-  `msg.sender == address(this)`, i.e. the EOA submitting its own type-4 tx.
-- `execute(Multicall[] calls, uint256 nonce, bytes signature)` — **sponsored**
-  path. A relayer submits while the EOA authorizes via an EIP-712 signature over
-  `(calls, nonce)`; the stored nonce is checked and bumped (replay-safe).
-- Reuses the existing `Multicall { address to; uint256 value; bytes data }` tuple
-  from `libraries/Types.sol`, so the SDK's call shape is unchanged.
-- Sequential execution, **revert bubbling** (original revert reason is
-  re-thrown), atomic at the tx level.
-- **ERC-7201 namespaced storage** for the nonce and reentrancy lock — required
-  because, under 7702, the contract's code runs in the *EOA's* storage, so a
-  fixed slot could collide with other delegate implementations the EOA might use.
+```solidity
+contract PushBatchExecutor is ERC7821 {
+    string public constant VERSION = "2.0.0";
+    receive() external payable {} // accept plain PC transfers to the delegated EOA
+}
+```
 
-**`test/tests_executor/PushBatchExecutor.t.sol`** (new) — 8 Foundry tests using
-`vm.signAndAttachDelegation` (real 7702 delegation): batch exec, self-call auth,
-value forwarding, sponsored exec + nonce bump, wrong-nonce, replay, foreign-signer
-rejection, and atomic revert + reason bubbling.
+- Authorization is inherited unchanged from `ERC7821`:
+  `_erc7821AuthorizedExecutor` ⇒ `caller == address(this)` — exactly the EIP-7702
+  self-call (the EOA submits its own type-4 tx). No custom auth code.
+- Entry point: `execute(bytes32 mode, bytes executionData)`. Single batch mode
+  only; `executionData = abi.encode(Execution[])`, `Execution = (address target,
+  uint256 value, bytes callData)`.
+- Sequential execution, **revert bubbling**, atomic at the tx level — all from
+  the OZ base. Stateless (no nonce/reentrancy storage needed: the
+  self-call gate already prevents external re-entry).
+- Requires **`@openzeppelin/contracts >= 5.4`** (where ERC-7821 lands); the
+  contracts repo's OZ submodule was bumped 5.3 → 5.4 (full repo still compiles).
+
+**`test/tests_executor/PushBatchExecutor.t.sol`** — 6 Foundry tests using
+`vm.signAndAttachDelegation` (real 7702 delegation): batch exec, self-call auth
+rejection, value forwarding, receiving plain native value while delegated,
+unsupported-mode rejection, and atomic revert + reason bubbling.
 
 ### SDK — `packages/core`
 
@@ -210,16 +220,18 @@ rejection, and atomic revert + reason bubbling.
 **3. `src/lib/constants/chain.ts`** — config + lookup.
 - `PUSH_BATCH_EXECUTOR_ADDRESS: Partial<Record<CHAIN, 0x...>>` — per-chain executor
   addresses. **Testnet Donut is set** to
-  `0x776d8031b9caA053d04325Bc2CAc47E5cb673776`; mainnet is unset (a chain with no
+  `0x0106BF2F9B02f32203A83a3bDaD79fE8818f3796`; mainnet is unset (a chain with no
   entry → `getBatchExecutorAddress()` returns `undefined` → SDK falls back).
 - `getBatchExecutorAddress(chain)` helper.
 
 **4. `src/lib/vm-client/evm-client.ts`** — the type-4 builder.
-- `PUSH_BATCH_EXECUTOR_ABI` and a `BatchCall` type.
-- `sendBatch7702({ executor, calls, signer })`: encodes `execute(calls)`, signs
-  the authorization (`nonce + 1`, self-delegation), serializes a `type: 'eip7702'`
-  transaction with `authorizationList`, and sends it via the existing
-  `signer.signAndSendTransaction`. Inherited by `PushClient extends EvmClient`.
+- `PUSH_BATCH_EXECUTOR_ABI` (ERC-7821 `execute(bytes32 mode, bytes executionData)`),
+  the `ERC7821_BATCH_MODE` constant, and a `BatchCall` type.
+- `sendBatch7702({ executor, calls, signer })`: encodes the ERC-7821 call
+  (`executionData = abi.encode(Execution[])`, batch mode), signs the authorization
+  (`nonce + 1`, self-delegation), serializes a `type: 'eip7702'` transaction with
+  `authorizationList`, and sends it via the existing `signer.signAndSendTransaction`.
+  Inherited by `PushClient extends EvmClient`.
 
 **5. `src/lib/orchestrator/internals/push-chain-tx.ts`** — the branch point.
 - In `sendPushTx`, when `data` is an array: if an executor is configured for the
@@ -272,7 +284,7 @@ value, so large batches don't out-of-gas relative to the old per-call loop.
 
 | Network | Address | Notes |
 | --- | --- | --- |
-| Push Testnet Donut (42101) | `0x776d8031b9caA053d04325Bc2CAc47E5cb673776` | deploy tx `0xbeed6f93…`, block 18373978 |
+| Push Testnet Donut (42101) | `0x0106BF2F9B02f32203A83a3bDaD79fE8818f3796` | OZ ERC-7821 + `receive()`; deploy tx `0xbbe4176a…`, block 18452893 |
 | Push Mainnet | — | mainnet not live yet — nothing to deploy |
 
 Deploy via `push-chain-core-contracts/scripts/executor/deployBatchExecutor.s.sol`
@@ -282,13 +294,14 @@ the address in `PUSH_BATCH_EXECUTOR_ADDRESS`.
 ### Contract source
 
 - **Canonical (compiled/tested/deployed):**
-  `push-chain-core-contracts/src/executor/PushBatchExecutor.sol`
+  `push-chain-core-contracts/src/executor/PushBatchExecutor.sol` — `is ERC7821`
+  (requires OZ ≥ 5.4).
 - **Vendored reference in this SDK (not built):**
-  `packages/core/src/lib/push-chain/helpers/PushBatchExecutor.sol` — a
-  self-contained copy (inlined `Multicall` struct) so the deployed source is
-  visible from the SDK without checking out the contracts repo.
-- **ABI used at runtime:** inlined as `PUSH_BATCH_EXECUTOR_ABI` in
-  `vm-client/evm-client.ts`.
+  `packages/core/src/lib/push-chain/helpers/PushBatchExecutor.sol` — the same
+  OZ ERC-7821 wrapper, so the deployed source is visible from the SDK without
+  checking out the contracts repo.
+- **ABI used at runtime:** `PUSH_BATCH_EXECUTOR_ABI` (ERC-7821
+  `execute(bytes32,bytes)`) in `vm-client/evm-client.ts`.
 
 ## What's not done yet
 
@@ -300,11 +313,13 @@ the address in `PUSH_BATCH_EXECUTOR_ADDRESS`.
 
 ## Verification status
 
-- **Contract:** 8 Foundry tests pass under real 7702 delegation
-  (`test/tests_executor/PushBatchExecutor.t.sol`).
+- **Contract:** 6 Foundry tests pass under real 7702 delegation
+  (`test/tests_executor/PushBatchExecutor.t.sol`); full contracts repo compiles
+  clean under the OZ 5.4 bump.
 - **SDK:** `tsc` clean; signer unit tests (16) pass, including 7702
   capability-gating cases (local account ⇒ capable, JSON-RPC ⇒ fall back).
-- **End-to-end (live testnet):** `__e2e__/scripts/e2e-7702-multicall.ts` — a
-  3-call multicall executed as a **single type-4 tx** (`0x2181e568…`); counter
-  advanced by exactly 3 atomically (1165 → 1168); EOA carries the delegation
-  designator `0xef0100‖executor`.
+- **End-to-end (live testnet, OZ ERC-7821 executor):**
+  `__e2e__/scripts/e2e-7702-multicall.ts` — a 3-call multicall executed as a
+  **single type-4 tx** (`0xcb1124e0…`); counter advanced by exactly 3 atomically
+  (1174 → 1177); EOA carries the delegation designator `0xef0100‖executor`. A
+  plain value transfer to the delegated EOA also succeeds (verifies `receive()`).

--- a/packages/core/docs/native-7702-batching.md
+++ b/packages/core/docs/native-7702-batching.md
@@ -1,0 +1,310 @@
+# Native EIP-7702 Batching for Push Chain Multicalls
+
+> Status: **live on Push testnet (Donut).** `PushBatchExecutor` is deployed at
+> `0x776d8031b9caA053d04325Bc2CAc47E5cb673776` (chain 42101) and wired into the
+> SDK; the native-Push multicall path now produces a single atomic type-4 tx.
+> Verified end-to-end (see "Verification status"). Push mainnet isn't live yet,
+> so there's no mainnet deployment.
+
+## TL;DR
+
+A native Push EOA that submits a "multicall" (an array of calls) used to get
+**N separate, non-atomic transactions**. This change makes it **one atomic
+EIP-7702 transaction**: the EOA delegates its code to a `PushBatchExecutor`
+contract for the duration of the tx and runs all calls in a single, all-or-nothing
+batch. If the wallet can't sign a 7702 authorization, the SDK falls back to the
+old behaviour and warns.
+
+Only the **native Push EOA** path changes. Bridged-EVM (via UEA proxy), outbound
+CEA batches, and SVM continue using the existing `UEA_MULTICALL` mechanism.
+
+---
+
+## Why
+
+### 1. The native multicall path was never atomic
+
+When the universal signer is on Push Chain itself, batches went through
+`sendPushTx` (`orchestrator/internals/push-chain-tx.ts`). For an array of calls
+it **looped and sent one transaction per call**, awaiting each receipt:
+
+```
+client.universal.sendTransaction({ to, data: [call1, call2, call3] })
+        │
+        ▼  sendPushTx — Array.isArray(data) → loop
+   ┌──────────────────────────────────────────────────────────────┐
+   │  TX #1 (nonce n)   EOA ─► call1.to   wait receipt ─► ✅        │
+   │  TX #2 (nonce n+1) EOA ─► call2.to   wait receipt ─► ❌ revert │
+   │  TX #3 ............ never sent (loop threw on #2)              │
+   └──────────────────────────────────────────────────────────────┘
+        ▼
+   ⚠️ call1 is already committed. No rollback. 3 sigs, 3 blocks.
+```
+
+Problems:
+
+- **Not atomic** — a later call reverting leaves earlier calls permanently
+  committed. There is no "all or nothing".
+- **Slow** — N signatures and N block confirmations.
+- **Inconsistent with the rest of the system** — bridged/SVM users already get
+  atomic batches via the UEA contract's `UEA_MULTICALL`. The native EOA path was
+  the outlier, because a plain EOA has no code to batch calls with.
+
+### 2. EIP-7702 is now live on Push Chain
+
+EIP-7702 (type-4 `SetCode` transactions) is enabled in the `pushchain/evm` fork:
+the EVM module implements authorization application/validation
+(`x/vm/keeper/state_transition.go`), the ante handler and mempool admit
+`SetCodeTxType`, and the Prague fork is active from genesis
+(`DefaultChainConfig` → `pragueTime = 0`). This lets an EOA temporarily adopt a
+contract's code, which is exactly the primitive needed to batch from an EOA.
+
+### 3. Goal
+
+Give the native EOA path a **real, atomic multicall** using native 7702 — without
+disturbing the UEA-proxy model that funds and represents bridged/SVM users.
+
+---
+
+## Scope decisions
+
+| Question | Decision |
+| --- | --- |
+| Which accounts? | **EVM + native Push (secp256k1) only.** SVM (ed25519) cannot sign a 7702 authorization, so it is out of scope. |
+| Account model | **Keep the UEA proxy as the funded account.** 7702 batching applies only where the executing signer *is* an EOA — the native-Push Route-1 path. |
+| Which batches? | **Push-Chain-native execution only.** Bridged-EVM-via-proxy, outbound CEA (executes on contracts / external chains), and SVM keep `UEA_MULTICALL`. |
+| Wallet without 7702 support | **Fall back to the legacy per-call loop + `console.warn`.** Capability-based: we only attempt 7702 when the signer exposes `signAuthorization`. |
+
+Why SVM is excluded: EIP-7702 authorizations are secp256k1 signatures whose
+recovered `authority` must equal the delegating account. An ed25519 (Solana) key
+cannot produce such a signature, so native 7702 is physically impossible for SVM
+accounts.
+
+---
+
+## Which multicalls use this path?
+
+The 7702 path is wired into a single route — `sendPushTx`, the **native-Push
+EOA** path (`isPushChain(signer.chain)` in `execute-standard.ts`). It engages
+**automatically** there (no caller/API change — same
+`sendTransaction({ to, data: calls })`), but **only** when all of these hold:
+
+1. The signer's origin is **Push Chain itself** (native EOA).
+2. An executor address is **configured for that chain** — currently **Testnet
+   Donut only**.
+3. The wallet can **actually sign a 7702 authorization** — a local viem account
+   or a working ethers v6 signer (see capability gating above).
+
+Everything else is unchanged and does **not** use 7702:
+
+| Multicall scenario | Path |
+| --- | --- |
+| Native Push EOA · Testnet Donut · 7702-capable wallet | ✅ **new 7702 atomic tx** |
+| Native Push EOA · 7702-incapable wallet (injected / JSON-RPC) | ↩ legacy per-call loop + warn |
+| Native Push EOA · chain with no executor configured | ↩ legacy per-call loop |
+| Bridged / cross-chain user (origin = Ethereum, Base, …) | UEA proxy `UEA_MULTICALL` (unchanged, already atomic) |
+| SVM / Solana signer | UEA `UEA_MULTICALL` (cannot 7702) |
+| Outbound CEA batches (execute on external chains) | custom multicall (unchanged) |
+
+Notes:
+
+- The large bucket — **bridged / cross-chain multicalls** — was already atomic
+  via the UEA proxy and stays on that path. 7702 only replaced the one route that
+  *wasn't* atomic: the native-Push EOA per-call loop.
+- **Mainnet does not exist yet**, so there is no mainnet executor and nothing to
+  configure there. When a Push mainnet launches, deploy the executor and set
+  `PUSH_BATCH_EXECUTOR_ADDRESS[CHAIN.PUSH_MAINNET]`; until then any non-testnet
+  native batch transparently uses the legacy loop.
+
+---
+
+## How it works now
+
+```
+client.universal.sendTransaction({ to, data: [call1, call2, call3] })
+        │
+        ▼  sendPushTx — executor configured? signer.signAuthorization present?
+        │                         │ yes
+        ▼                         ▼  EvmClient.sendBatch7702()
+   ┌─────────────────────────────────────────────────────────────────┐
+   │ 1. sign 7702 authorization (EOA key):                            │
+   │      { chainId, address: EXECUTOR, nonce: n+1, r, s, yParity }    │
+   │ 2. data = PushBatchExecutor.execute([call1, call2, call3])       │
+   │ 3. serialize ONE type-4 (eip7702) tx:                            │
+   │      to = EOA (self), nonce = n, authorizationList = [auth]       │
+   └─────────────────────────────────────────────────────────────────┘
+        │  one signed type-4 tx
+        ▼
+   ┌──────────────────── single transaction (atomic) ─────────────────┐
+   │ ① node applies authorization: EOA.code ← 0xef0100 ‖ EXECUTOR      │
+   │ ② tx calls EOA.execute([calls]); msg.sender == address(this)      │
+   │      → executor's self-call check passes (no per-call sig)        │
+   │      ├─ call1 ✅  ├─ call2 ❌ revert  → WHOLE TX REVERTS           │
+   │      └─ call1 rolled back                                         │
+   └───────────────────────────────────────────────────────────────────┘
+        ▼
+   ✅ all-or-nothing, 1 tx, 1 receipt
+```
+
+Two subtleties worth noting:
+
+- **Authorization nonce is `n + 1`, not `n`.** In self-execution the transaction
+  consumes the sender's nonce `n` first; EIP-7702 then validates the
+  authorization against the already-incremented nonce. `sendBatch7702` sets
+  `nonce: nonce + 1` accordingly.
+- **Gas estimation uses a state override.** Before the tx, the EOA has no code,
+  so estimating `execute(...)` against it would under-estimate. We override the
+  account's code with the delegation designator (`0xef0100 ‖ executor`) so the
+  estimate runs the executor, then add 20% headroom. If the node rejects
+  overrides, the fallback ceiling scales with the batch size
+  (`500_000 * calls.length + 100_000`) so large batches don't out-of-gas.
+
+---
+
+## What changed
+
+### Contract — `push-chain-core-contracts`
+
+**`src/executor/PushBatchExecutor.sol`** (new) — the EIP-7702 delegation target.
+
+- `execute(Multicall[] calls)` — **self-sponsored** path. Requires
+  `msg.sender == address(this)`, i.e. the EOA submitting its own type-4 tx.
+- `execute(Multicall[] calls, uint256 nonce, bytes signature)` — **sponsored**
+  path. A relayer submits while the EOA authorizes via an EIP-712 signature over
+  `(calls, nonce)`; the stored nonce is checked and bumped (replay-safe).
+- Reuses the existing `Multicall { address to; uint256 value; bytes data }` tuple
+  from `libraries/Types.sol`, so the SDK's call shape is unchanged.
+- Sequential execution, **revert bubbling** (original revert reason is
+  re-thrown), atomic at the tx level.
+- **ERC-7201 namespaced storage** for the nonce and reentrancy lock — required
+  because, under 7702, the contract's code runs in the *EOA's* storage, so a
+  fixed slot could collide with other delegate implementations the EOA might use.
+
+**`test/tests_executor/PushBatchExecutor.t.sol`** (new) — 8 Foundry tests using
+`vm.signAndAttachDelegation` (real 7702 delegation): batch exec, self-call auth,
+value forwarding, sponsored exec + nonce bump, wrong-nonce, replay, foreign-signer
+rejection, and atomic revert + reason bubbling.
+
+### SDK — `packages/core`
+
+**1. `src/lib/universal/universal.types.ts`** — extend the signer abstraction.
+- New `SignAuthorizationParams` and `SignedAuthorization` types.
+- New **optional** `signAuthorization?(params)` on `UniversalSigner` and
+  `UniversalSignerSkeleton`. Optional so non-EVM / non-7702 wallets are
+  unaffected and trigger the fallback.
+
+**2. `src/lib/universal/signer/signer.ts`** — implement it (two shared helpers,
+`viemSignAuthorization` / `ethersSignAuthorization`, used by both the keypair and
+`toUniversal` paths).
+- viem (`LIBRARY.ETHEREUM_VIEM`): gated on the **account** —
+  `account.signAuthorization` (present only on local accounts), since viem
+  exposes the client action even for JSON-RPC accounts that can't sign offline.
+- ethers v6 (`LIBRARY.ETHEREUM_ETHERSV6`): delegates to `signer.authorize()`,
+  guarded by method presence and backed by the runtime fallback (see below),
+  since `AbstractSigner.authorize`'s default throws.
+- Wired through `createUniversalSigner`, the keypair signer object, AND the
+  `toUniversal` skeleton generators (`generateSkeletonFromViem`,
+  `generateSkeletonFromEthersV6`). SVM, ethers v5, and custom-skeleton paths
+  leave it `undefined`.
+
+**3. `src/lib/constants/chain.ts`** — config + lookup.
+- `PUSH_BATCH_EXECUTOR_ADDRESS: Partial<Record<CHAIN, 0x...>>` — per-chain executor
+  addresses. **Testnet Donut is set** to
+  `0x776d8031b9caA053d04325Bc2CAc47E5cb673776`; mainnet is unset (a chain with no
+  entry → `getBatchExecutorAddress()` returns `undefined` → SDK falls back).
+- `getBatchExecutorAddress(chain)` helper.
+
+**4. `src/lib/vm-client/evm-client.ts`** — the type-4 builder.
+- `PUSH_BATCH_EXECUTOR_ABI` and a `BatchCall` type.
+- `sendBatch7702({ executor, calls, signer })`: encodes `execute(calls)`, signs
+  the authorization (`nonce + 1`, self-delegation), serializes a `type: 'eip7702'`
+  transaction with `authorizationList`, and sends it via the existing
+  `signer.signAndSendTransaction`. Inherited by `PushClient extends EvmClient`.
+
+**5. `src/lib/orchestrator/internals/push-chain-tx.ts`** — the branch point.
+- In `sendPushTx`, when `data` is an array: if an executor is configured for the
+  chain **and** the signer supports `signAuthorization`, route through
+  `sendBatch7702` (single atomic tx). Otherwise `console.warn` and fall through to
+  the existing per-call loop (unchanged).
+
+---
+
+## Fallback behaviour & wallet capability
+
+The 7702 path is attempted only when **both** are true:
+
+1. `getBatchExecutorAddress(chain)` returns an address (contract deployed +
+   configured), and
+2. `signer.signAuthorization` exists.
+
+**Capability detection is conservative.** Method *presence* is not trusted as a
+capability signal:
+
+- **viem** exposes `signAuthorization` on every WalletClient (even JSON-RPC
+  accounts that can't sign one). We therefore gate on the **account** — only
+  local accounts (`account.signAuthorization`) get the capability; JSON-RPC
+  accounts get `undefined` and fall back. (Covered by unit tests.)
+- **ethers v6** has `authorize` on `AbstractSigner` whose default throws, so
+  presence alone is unreliable.
+
+To cover the cases capability-detection can't (a method that exists but throws),
+`sendBatch7702` signs the authorization **before** building/broadcasting any
+transaction; if that step throws it raises `EIP7702NotSupportedError`. The
+orchestrator catches **only** that error and falls back to the sequential loop —
+safe because nothing was broadcast. Any other error (a real revert, RPC failure
+after broadcast) is surfaced, never silently downgraded.
+
+When falling back (or when the wallet has no 7702 capability at all), a
+`console.warn` notes the batch will run as separate, non-atomic transactions.
+
+**ethers type-4 shape.** `toEthersTxRequest` converts viem-shaped
+`authorizationList` entries (`r`/`s`/`yParity`) into ethers' nested `signature`
+form and sets `type: 4`; without this ethers normalises them to a zero signature
+and the delegation is silently dropped.
+
+**Gas fallback.** If state-override gas estimation is unavailable, the fallback
+ceiling scales with `calls.length` (`~500k`/call + overhead) rather than a flat
+value, so large batches don't out-of-gas relative to the old per-call loop.
+
+---
+
+## Deployment
+
+| Network | Address | Notes |
+| --- | --- | --- |
+| Push Testnet Donut (42101) | `0x776d8031b9caA053d04325Bc2CAc47E5cb673776` | deploy tx `0xbeed6f93…`, block 18373978 |
+| Push Mainnet | — | mainnet not live yet — nothing to deploy |
+
+Deploy via `push-chain-core-contracts/scripts/executor/deployBatchExecutor.s.sol`
+(or `forge create src/executor/PushBatchExecutor.sol:PushBatchExecutor`), then set
+the address in `PUSH_BATCH_EXECUTOR_ADDRESS`.
+
+### Contract source
+
+- **Canonical (compiled/tested/deployed):**
+  `push-chain-core-contracts/src/executor/PushBatchExecutor.sol`
+- **Vendored reference in this SDK (not built):**
+  `packages/core/src/lib/push-chain/helpers/PushBatchExecutor.sol` — a
+  self-contained copy (inlined `Multicall` struct) so the deployed source is
+  visible from the SDK without checking out the contracts repo.
+- **ABI used at runtime:** inlined as `PUSH_BATCH_EXECUTOR_ABI` in
+  `vm-client/evm-client.ts`.
+
+## What's not done yet
+
+- **Mainnet:** not applicable yet — Push mainnet isn't live. Once it is, deploy
+  the executor and set `PUSH_BATCH_EXECUTOR_ADDRESS[CHAIN.PUSH_MAINNET]`.
+- Fold the standalone e2e (`__e2e__/scripts/e2e-7702-multicall.ts`) into the jest
+  e2e suite (the existing `native.spec.ts` UTX-21 case now routes through 7702
+  automatically).
+
+## Verification status
+
+- **Contract:** 8 Foundry tests pass under real 7702 delegation
+  (`test/tests_executor/PushBatchExecutor.t.sol`).
+- **SDK:** `tsc` clean; signer unit tests (16) pass, including 7702
+  capability-gating cases (local account ⇒ capable, JSON-RPC ⇒ fall back).
+- **End-to-end (live testnet):** `__e2e__/scripts/e2e-7702-multicall.ts` — a
+  3-call multicall executed as a **single type-4 tx** (`0x2181e568…`); counter
+  advanced by exactly 3 atomically (1165 → 1168); EOA carries the delegation
+  designator `0xef0100‖executor`.

--- a/packages/core/src/lib/constants/chain.ts
+++ b/packages/core/src/lib/constants/chain.ts
@@ -176,6 +176,32 @@ export const SYNTHETIC_PUSH_ERC20: Record<
  * References -
  * https://namespaces.chainagnostic.org/solana/caip2
  */
+/**
+ * EIP-7702 batch executor (`PushBatchExecutor`) delegation targets, per chain.
+ *
+ * Native Push EOAs delegate their code to this contract (via a type-4 / SetCode
+ * transaction) to execute a `MultiCall[]` batch atomically in a single tx,
+ * replacing the legacy non-atomic per-call loop.
+ *
+ * An entry is absent until the contract is deployed to that chain. When absent,
+ * the SDK falls back to sequential single-call execution. Fill in the address
+ * after deploying `push-chain-core-contracts/src/executor/PushBatchExecutor.sol`.
+ */
+export const PUSH_BATCH_EXECUTOR_ADDRESS: Partial<Record<CHAIN, `0x${string}`>> =
+  {
+    // Deployed 2026-06-22, tx 0xbeed6f93…, block 18373978.
+    [CHAIN.PUSH_TESTNET_DONUT]:
+      '0x776d8031b9caA053d04325Bc2CAc47E5cb673776',
+    // [CHAIN.PUSH_MAINNET]: '0x...', // TODO: set after mainnet deploy
+  };
+
+/** Returns the configured 7702 batch-executor address for a chain, if any. */
+export function getBatchExecutorAddress(
+  chain: CHAIN
+): `0x${string}` | undefined {
+  return PUSH_BATCH_EXECUTOR_ADDRESS[chain];
+}
+
 export const CHAIN_INFO: Record<
   CHAIN,
   {

--- a/packages/core/src/lib/constants/chain.ts
+++ b/packages/core/src/lib/constants/chain.ts
@@ -189,9 +189,10 @@ export const SYNTHETIC_PUSH_ERC20: Record<
  */
 export const PUSH_BATCH_EXECUTOR_ADDRESS: Partial<Record<CHAIN, `0x${string}`>> =
   {
-    // Deployed 2026-06-22, tx 0xbeed6f93…, block 18373978.
+    // OpenZeppelin ERC-7821 based executor (with payable receive), deployed
+    // 2026-06-22, tx 0xbbe4176a….
     [CHAIN.PUSH_TESTNET_DONUT]:
-      '0x776d8031b9caA053d04325Bc2CAc47E5cb673776',
+      '0x0106BF2F9B02f32203A83a3bDaD79fE8818f3796',
     // [CHAIN.PUSH_MAINNET]: '0x...', // TODO: set after mainnet deploy
   };
 

--- a/packages/core/src/lib/orchestrator/internals/push-chain-tx.ts
+++ b/packages/core/src/lib/orchestrator/internals/push-chain-tx.ts
@@ -265,7 +265,11 @@ export async function sendPushTx(
       lastTxHash,
       'sendPushTx'
     );
-    return await transformFn(txResponse, eventBuffer);
+    // Sequential fallback: each call was a separate tx, so the batch is NOT
+    // atomic (an earlier call can be committed while a later one reverts).
+    const resp = await transformFn(txResponse, eventBuffer);
+    resp.atomic = false;
+    return resp;
   }
 
   const txHash = await ctx.pushClient.sendTransaction({

--- a/packages/core/src/lib/orchestrator/internals/push-chain-tx.ts
+++ b/packages/core/src/lib/orchestrator/internals/push-chain-tx.ts
@@ -8,7 +8,11 @@
 import { bs58 } from '../../internal/bs58';
 type Any = { typeUrl: string; value: Uint8Array };
 import { bytesToHex } from 'viem';
-import { CHAIN_INFO, VM_NAMESPACE } from '../../constants/chain';
+import {
+  CHAIN_INFO,
+  VM_NAMESPACE,
+  getBatchExecutorAddress,
+} from '../../constants/chain';
 import { VM } from '../../constants/enums';
 import type { UniversalTx } from '../../generated/uexecutor/v1/types';
 import { PROGRESS_HOOK, ProgressEvent } from '../../progress-hook/progress-hook.types';
@@ -17,6 +21,7 @@ import {
   UniversalPayload,
 } from '../../generated/v1/tx';
 import type { TxResponse } from '../../vm-client/vm-client.types';
+import { EIP7702NotSupportedError } from '../../vm-client/evm-client';
 import type {
   ExecuteParams,
   MultiCall,
@@ -107,6 +112,58 @@ export async function sendPushTx(
   transformFn: TransformToResponseFn
 ): Promise<UniversalTxResponse> {
   if (Array.isArray(execute.data)) {
+    const calls = execute.data as MultiCall[];
+
+    // Preferred path: execute the batch atomically in a single EIP-7702 type-4
+    // transaction. Requires (a) a deployed PushBatchExecutor on this chain and
+    // (b) a wallet that can sign a 7702 authorization. When either is missing we
+    // fall back to the legacy non-atomic per-call loop below.
+    const executor = getBatchExecutorAddress(
+      ctx.universalSigner.account.chain
+    );
+    if (executor && ctx.universalSigner.signAuthorization) {
+      try {
+        printLog(
+          ctx,
+          `sendPushTx — executing ${calls.length} call(s) atomically via EIP-7702 (executor: ${executor})`
+        );
+        const txHash = await ctx.pushClient.sendBatch7702({
+          executor,
+          calls,
+          signer: ctx.universalSigner,
+        });
+        const txResponse = await getIndexedPushTransaction(
+          ctx,
+          txHash,
+          'sendPushTx'
+        );
+        return await transformFn(txResponse, eventBuffer);
+      } catch (err) {
+        // Only fall back when the wallet genuinely can't sign a 7702
+        // authorization. This is raised before any broadcast, so falling back
+        // to sequential execution cannot double-execute. Any other error
+        // (e.g. a real revert) must surface.
+        if (!(err instanceof EIP7702NotSupportedError)) throw err;
+        printLog(
+          ctx,
+          `sendPushTx — wallet cannot sign EIP-7702 authorization; falling back to sequential execution`
+        );
+        // eslint-disable-next-line no-console
+        console.warn(
+          '[push-chain] Wallet cannot produce an EIP-7702 authorization — batch ' +
+            'will execute as separate, non-atomic transactions (if one call reverts, ' +
+            'earlier calls remain committed).'
+        );
+      }
+    } else if (!ctx.universalSigner.signAuthorization) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[push-chain] Signer does not support EIP-7702 — batch will execute as ' +
+          'separate, non-atomic transactions (if one call reverts, earlier calls ' +
+          'remain committed).'
+      );
+    }
+
     const PUSH_CHAIN_GAS_LIMIT = BigInt(500000);
     const MAX_NONCE_RETRIES = 3;
     let nonce = await ctx.pushClient.publicClient.getTransactionCount({
@@ -114,7 +171,6 @@ export async function sendPushTx(
       blockTag: 'pending',
     });
     let lastTxHash: `0x${string}` = '0x';
-    const calls = execute.data as MultiCall[];
     for (let i = 0; i < calls.length; i++) {
       const call = calls[i];
       let txSent = false;

--- a/packages/core/src/lib/orchestrator/internals/push-chain-tx.ts
+++ b/packages/core/src/lib/orchestrator/internals/push-chain-tx.ts
@@ -114,6 +114,17 @@ export async function sendPushTx(
   if (Array.isArray(execute.data)) {
     const calls = execute.data as MultiCall[];
 
+    // Reject a zero `to` BEFORE route selection so behaviour is identical
+    // regardless of signer capability: ERC-7821 (the 7702 path) reinterprets
+    // `target == 0` as the account itself, whereas the legacy loop would send to
+    // the zero address. A zero target is almost always a bug — disallow it.
+    if (calls.some((c) => /^0x0{40}$/i.test(c.to))) {
+      throw new PushChainExecutionError(
+        'A multicall entry has a zero `to` address. Use an explicit target ' +
+          '(the EIP-7702 executor reinterprets a zero target as the account itself).'
+      );
+    }
+
     // Preferred path: execute the batch atomically in a single EIP-7702 type-4
     // transaction. Requires (a) a deployed PushBatchExecutor on this chain and
     // (b) a wallet that can sign a 7702 authorization. When either is missing we

--- a/packages/core/src/lib/orchestrator/internals/response-builder.ts
+++ b/packages/core/src/lib/orchestrator/internals/response-builder.ts
@@ -1131,6 +1131,12 @@ export async function transformToUniversalTxResponse(
     // 7. Metadata
     type,
     typeVerbose,
+    // Atomic by default — a single tx, an EIP-7702 batch, and a UEA multicall
+    // are all all-or-nothing. Only the native sequential fallback loop overrides
+    // this to `false` (see sendPushTx in push-chain-tx.ts). Historical lookups
+    // via trackTransaction also keep the default, since the past execution mode
+    // isn't always recoverable.
+    atomic: true,
     signature,
 
     // 8. Raw Universal Fields

--- a/packages/core/src/lib/orchestrator/orchestrator.types.ts
+++ b/packages/core/src/lib/orchestrator/orchestrator.types.ts
@@ -287,6 +287,13 @@ export interface UniversalTxResponse {
   // 7. Metadata
   type: string; // "99" (was typeHex), now string
   typeVerbose: string; // "universal" (was type), human readable
+  /**
+   * Whether the transaction executed atomically (all-or-nothing).
+   * `true` for a single tx, an EIP-7702 batch, or a UEA `UEA_MULTICALL` batch;
+   * `false` only when a multicall fell back to the non-atomic sequential loop
+   * (separate per-call txs — an earlier call can commit while a later one reverts).
+   */
+  atomic: boolean;
   signature: Signature; // ethers Signature instance
 
   // 8. Raw Universal Fields (if you ever need them)

--- a/packages/core/src/lib/push-chain/helpers/PushBatchExecutor.sol
+++ b/packages/core/src/lib/push-chain/helpers/PushBatchExecutor.sol
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+// ============================================================================
+// VENDORED REFERENCE COPY — NOT compiled by the SDK build.
+//
+// This is the source of the EIP-7702 batch executor that the SDK delegates to
+// for native-Push atomic multicalls (see `EvmClient.sendBatch7702` and
+// `PUSH_BATCH_EXECUTOR_ADDRESS` in constants/chain.ts).
+//
+//   Deployed: 0x776d8031b9caA053d04325Bc2CAc47E5cb673776
+//   Network:  Push Testnet Donut (chain 42101)
+//   Deploy tx: 0xbeed6f9351212ede19ea644bd034146eaef748fab18f69c77397badbc057c169
+//
+// Canonical / verification source (compiled, tested, deployed from there):
+//   push-chain-core-contracts/src/executor/PushBatchExecutor.sol
+//
+// The only divergence from the canonical file is that the `Multicall` struct is
+// inlined here (canonical imports it from `../libraries/Types.sol`) so this copy
+// is self-contained. Logic and storage layout are identical.
+// ============================================================================
+
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+
+/// @notice Inlined from push-chain-core-contracts `libraries/Types.sol`.
+struct Multicall {
+    address to; // Target contract address to call
+    uint256 value; // Native token amount to send
+    bytes data; // Call data for the function execution
+}
+
+/**
+ * @title   PushBatchExecutor
+ * @notice  EIP-7702 delegation target that batch-executes a list of calls atomically.
+ * @dev     This contract is NOT deployed-and-called like the UEA proxy. Instead an EVM
+ *          EOA on Push Chain delegates its code to this implementation via an EIP-7702
+ *          authorization (`SetCodeTx`, tx type 0x04). After delegation, the executor's
+ *          code runs in the *EOA's* own storage and balance context, so `address(this)`
+ *          IS the user's account.
+ *
+ *          It replaces the custom `UEA_MULTICALL` selector path for secp256k1 (EVM-origin
+ *          and native Push) accounts. SVM (ed25519) accounts cannot sign a 7702
+ *          authorization and continue to use the UEA multicall path.
+ *
+ *          Two entrypoints:
+ *            1. {execute(Multicall[])}            — self-sponsored. Only callable when
+ *               `msg.sender == address(this)`, i.e. the EOA submits its own type-4 tx.
+ *               The transaction's own nonce + signature provide replay protection, so no
+ *               extra signature is required.
+ *            2. {execute(Multicall[],uint256,bytes)} — sponsored/relayed. A third party
+ *               pays gas while the EOA's key authorizes the batch via an EIP-712
+ *               signature bound to an internal nonce. Mirrors the existing relayer model.
+ *
+ *          Because the code executes in the EOA's storage, all persistent state lives in
+ *          an ERC-7201 namespaced slot to avoid colliding with other delegate
+ *          implementations the same EOA might use over its lifetime.
+ */
+contract PushBatchExecutor {
+    using ECDSA for bytes32;
+
+    // =========================
+    //          ERRORS
+    // =========================
+
+    /// @notice Caller is neither the account itself nor a valid sponsored signature.
+    error Unauthorized();
+    /// @notice The supplied batch nonce does not match the stored nonce.
+    error InvalidNonce(uint256 expected, uint256 provided);
+    /// @notice A call in the batch reverted; the original revert reason is bubbled up.
+    error CallReverted(uint256 index);
+    /// @notice Reentrant entry into the executor.
+    error Reentrancy();
+
+    // =========================
+    //          EVENTS
+    // =========================
+
+    /// @notice Emitted once per successful batch, after all calls have executed.
+    event BatchExecuted(address indexed account, uint256 indexed nonce, uint256 callCount);
+
+    // =========================
+    //        CONSTANTS
+    // =========================
+
+    /// @notice Implementation version.
+    string public constant VERSION = "1.0.0";
+
+    /// @notice EIP-712 type hashes for the sponsored execution path.
+    bytes32 private constant EIP712_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 private constant CALL_TYPEHASH = keccak256("Call(address to,uint256 value,bytes data)");
+    bytes32 private constant EXECUTE_TYPEHASH =
+        keccak256("Execute(Call[] calls,uint256 nonce)Call(address to,uint256 value,bytes data)");
+
+    /// @dev ERC-7201 namespaced storage root:
+    ///      keccak256(abi.encode(uint256(keccak256("push.storage.PushBatchExecutor")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant STORAGE_SLOT = 0x0e9e156a7f7c2f9efdb8f9b6cf24ddc7734a3c6bbbd39ddde542536e731f3e00;
+
+    /// @custom:storage-location erc7201:push.storage.PushBatchExecutor
+    struct ExecutorStorage {
+        uint256 nonce; // monotonic nonce for the sponsored (signed) path
+        uint256 locked; // reentrancy flag (1 = entered)
+    }
+
+    function _s() private pure returns (ExecutorStorage storage $) {
+        assembly {
+            $.slot := STORAGE_SLOT
+        }
+    }
+
+    // =========================
+    //        MODIFIERS
+    // =========================
+
+    modifier nonReentrant() {
+        ExecutorStorage storage $ = _s();
+        if ($.locked == 1) revert Reentrancy();
+        $.locked = 1;
+        _;
+        $.locked = 0;
+    }
+
+    // =========================
+    //        VIEW
+    // =========================
+
+    /// @notice Current nonce for the sponsored execution path on this account.
+    function nonce() external view returns (uint256) {
+        return _s().nonce;
+    }
+
+    /// @notice EIP-712 domain separator, bound to this account (`address(this)`) and Push Chain.
+    function domainSeparator() public view returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                EIP712_DOMAIN_TYPEHASH,
+                keccak256(bytes("PushBatchExecutor")),
+                keccak256(bytes(VERSION)),
+                block.chainid,
+                address(this)
+            )
+        );
+    }
+
+    // =========================
+    //        EXECUTION
+    // =========================
+
+    /**
+     * @notice Self-sponsored batch execution. Only callable by the account itself, i.e.
+     *         when the EOA submits its own EIP-7702 type-4 transaction.
+     * @param  calls The ordered list of calls to execute. Reverts the whole batch on the
+     *         first failing call.
+     */
+    function execute(Multicall[] calldata calls) external payable nonReentrant {
+        if (msg.sender != address(this)) revert Unauthorized();
+        _execute(calls);
+        emit BatchExecuted(address(this), 0, calls.length);
+    }
+
+    /**
+     * @notice Sponsored batch execution. Any caller may relay the batch as long as it is
+     *         authorized by an EIP-712 signature from this account's key over
+     *         `(calls, batchNonce)`. Consumes and increments the stored nonce.
+     * @param  calls      The ordered list of calls to execute.
+     * @param  batchNonce Must equal the account's current stored nonce.
+     * @param  signature  ECDSA signature by `address(this)` over the EIP-712 digest.
+     */
+    function execute(Multicall[] calldata calls, uint256 batchNonce, bytes calldata signature)
+        external
+        payable
+        nonReentrant
+    {
+        ExecutorStorage storage $ = _s();
+        uint256 current = $.nonce;
+        if (batchNonce != current) revert InvalidNonce(current, batchNonce);
+
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator(), _hashBatch(calls, batchNonce)));
+        address signer = digest.recover(signature);
+        // The authorizing key must be this very account (the EOA that delegated to us).
+        if (signer != address(this)) revert Unauthorized();
+
+        unchecked {
+            $.nonce = current + 1;
+        }
+
+        _execute(calls);
+        emit BatchExecuted(address(this), batchNonce, calls.length);
+    }
+
+    // =========================
+    //        INTERNAL
+    // =========================
+
+    /// @dev Executes calls sequentially, bubbling up the original revert reason on failure.
+    function _execute(Multicall[] calldata calls) private {
+        for (uint256 i = 0; i < calls.length; ++i) {
+            (bool ok, bytes memory ret) = calls[i].to.call{value: calls[i].value}(calls[i].data);
+            if (!ok) {
+                // Bubble up the underlying revert reason if present; otherwise a typed error.
+                if (ret.length > 0) {
+                    assembly {
+                        revert(add(ret, 0x20), mload(ret))
+                    }
+                }
+                revert CallReverted(i);
+            }
+        }
+    }
+
+    /// @dev EIP-712 struct hash for the `Execute` payload.
+    function _hashBatch(Multicall[] calldata calls, uint256 batchNonce) private pure returns (bytes32) {
+        bytes32[] memory callHashes = new bytes32[](calls.length);
+        for (uint256 i = 0; i < calls.length; ++i) {
+            callHashes[i] =
+                keccak256(abi.encode(CALL_TYPEHASH, calls[i].to, calls[i].value, keccak256(calls[i].data)));
+        }
+        return keccak256(abi.encode(EXECUTE_TYPEHASH, keccak256(abi.encodePacked(callHashes)), batchNonce));
+    }
+
+    /// @notice Accept native value (e.g. funding the account before a batch with `value` calls).
+    receive() external payable {}
+}

--- a/packages/core/src/lib/push-chain/helpers/PushBatchExecutor.sol
+++ b/packages/core/src/lib/push-chain/helpers/PushBatchExecutor.sol
@@ -4,220 +4,34 @@ pragma solidity 0.8.26;
 // ============================================================================
 // VENDORED REFERENCE COPY — NOT compiled by the SDK build.
 //
-// This is the source of the EIP-7702 batch executor that the SDK delegates to
-// for native-Push atomic multicalls (see `EvmClient.sendBatch7702` and
-// `PUSH_BATCH_EXECUTOR_ADDRESS` in constants/chain.ts).
+// The EIP-7702 batch executor the SDK delegates to for native-Push atomic
+// multicalls (see `EvmClient.sendBatch7702` and `PUSH_BATCH_EXECUTOR_ADDRESS`
+// in constants/chain.ts). It is a thin wrapper over OpenZeppelin's ERC-7821
+// implementation (`draft-ERC7821`); ERC-7821's default authorization
+// (`caller == address(this)`) is exactly the EIP-7702 self-call.
 //
-//   Deployed: 0x776d8031b9caA053d04325Bc2CAc47E5cb673776
+//   Deployed: 0x0106BF2F9B02f32203A83a3bDaD79fE8818f3796
 //   Network:  Push Testnet Donut (chain 42101)
-//   Deploy tx: 0xbeed6f9351212ede19ea644bd034146eaef748fab18f69c77397badbc057c169
+//   Deploy tx: 0xbbe4176ae85c7a737ac62df9fa15aa16cb852b9175458fba22d7177c09106277
 //
 // Canonical / verification source (compiled, tested, deployed from there):
 //   push-chain-core-contracts/src/executor/PushBatchExecutor.sol
+//   (requires @openzeppelin/contracts >= 5.4 for ERC7821)
 //
-// The only divergence from the canonical file is that the `Multicall` struct is
-// inlined here (canonical imports it from `../libraries/Types.sol`) so this copy
-// is self-contained. Logic and storage layout are identical.
+// Call shape:
+//   mode          = 0x01..00 (ERC-7821 single batch, default exec, selector 0)
+//   executionData = abi.encode(Execution[])  where
+//                   Execution = (address target, uint256 value, bytes callData)
 // ============================================================================
 
-import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {ERC7821} from "@openzeppelin/contracts/account/extensions/draft-ERC7821.sol";
 
-/// @notice Inlined from push-chain-core-contracts `libraries/Types.sol`.
-struct Multicall {
-    address to; // Target contract address to call
-    uint256 value; // Native token amount to send
-    bytes data; // Call data for the function execution
-}
+contract PushBatchExecutor is ERC7821 {
+    /// @notice Implementation version. 2.x = ERC-7821 (OZ) based.
+    string public constant VERSION = "2.0.0";
 
-/**
- * @title   PushBatchExecutor
- * @notice  EIP-7702 delegation target that batch-executes a list of calls atomically.
- * @dev     This contract is NOT deployed-and-called like the UEA proxy. Instead an EVM
- *          EOA on Push Chain delegates its code to this implementation via an EIP-7702
- *          authorization (`SetCodeTx`, tx type 0x04). After delegation, the executor's
- *          code runs in the *EOA's* own storage and balance context, so `address(this)`
- *          IS the user's account.
- *
- *          It replaces the custom `UEA_MULTICALL` selector path for secp256k1 (EVM-origin
- *          and native Push) accounts. SVM (ed25519) accounts cannot sign a 7702
- *          authorization and continue to use the UEA multicall path.
- *
- *          Two entrypoints:
- *            1. {execute(Multicall[])}            — self-sponsored. Only callable when
- *               `msg.sender == address(this)`, i.e. the EOA submits its own type-4 tx.
- *               The transaction's own nonce + signature provide replay protection, so no
- *               extra signature is required.
- *            2. {execute(Multicall[],uint256,bytes)} — sponsored/relayed. A third party
- *               pays gas while the EOA's key authorizes the batch via an EIP-712
- *               signature bound to an internal nonce. Mirrors the existing relayer model.
- *
- *          Because the code executes in the EOA's storage, all persistent state lives in
- *          an ERC-7201 namespaced slot to avoid colliding with other delegate
- *          implementations the same EOA might use over its lifetime.
- */
-contract PushBatchExecutor {
-    using ECDSA for bytes32;
-
-    // =========================
-    //          ERRORS
-    // =========================
-
-    /// @notice Caller is neither the account itself nor a valid sponsored signature.
-    error Unauthorized();
-    /// @notice The supplied batch nonce does not match the stored nonce.
-    error InvalidNonce(uint256 expected, uint256 provided);
-    /// @notice A call in the batch reverted; the original revert reason is bubbled up.
-    error CallReverted(uint256 index);
-    /// @notice Reentrant entry into the executor.
-    error Reentrancy();
-
-    // =========================
-    //          EVENTS
-    // =========================
-
-    /// @notice Emitted once per successful batch, after all calls have executed.
-    event BatchExecuted(address indexed account, uint256 indexed nonce, uint256 callCount);
-
-    // =========================
-    //        CONSTANTS
-    // =========================
-
-    /// @notice Implementation version.
-    string public constant VERSION = "1.0.0";
-
-    /// @notice EIP-712 type hashes for the sponsored execution path.
-    bytes32 private constant EIP712_DOMAIN_TYPEHASH =
-        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
-    bytes32 private constant CALL_TYPEHASH = keccak256("Call(address to,uint256 value,bytes data)");
-    bytes32 private constant EXECUTE_TYPEHASH =
-        keccak256("Execute(Call[] calls,uint256 nonce)Call(address to,uint256 value,bytes data)");
-
-    /// @dev ERC-7201 namespaced storage root:
-    ///      keccak256(abi.encode(uint256(keccak256("push.storage.PushBatchExecutor")) - 1)) & ~bytes32(uint256(0xff))
-    bytes32 private constant STORAGE_SLOT = 0x0e9e156a7f7c2f9efdb8f9b6cf24ddc7734a3c6bbbd39ddde542536e731f3e00;
-
-    /// @custom:storage-location erc7201:push.storage.PushBatchExecutor
-    struct ExecutorStorage {
-        uint256 nonce; // monotonic nonce for the sponsored (signed) path
-        uint256 locked; // reentrancy flag (1 = entered)
-    }
-
-    function _s() private pure returns (ExecutorStorage storage $) {
-        assembly {
-            $.slot := STORAGE_SLOT
-        }
-    }
-
-    // =========================
-    //        MODIFIERS
-    // =========================
-
-    modifier nonReentrant() {
-        ExecutorStorage storage $ = _s();
-        if ($.locked == 1) revert Reentrancy();
-        $.locked = 1;
-        _;
-        $.locked = 0;
-    }
-
-    // =========================
-    //        VIEW
-    // =========================
-
-    /// @notice Current nonce for the sponsored execution path on this account.
-    function nonce() external view returns (uint256) {
-        return _s().nonce;
-    }
-
-    /// @notice EIP-712 domain separator, bound to this account (`address(this)`) and Push Chain.
-    function domainSeparator() public view returns (bytes32) {
-        return keccak256(
-            abi.encode(
-                EIP712_DOMAIN_TYPEHASH,
-                keccak256(bytes("PushBatchExecutor")),
-                keccak256(bytes(VERSION)),
-                block.chainid,
-                address(this)
-            )
-        );
-    }
-
-    // =========================
-    //        EXECUTION
-    // =========================
-
-    /**
-     * @notice Self-sponsored batch execution. Only callable by the account itself, i.e.
-     *         when the EOA submits its own EIP-7702 type-4 transaction.
-     * @param  calls The ordered list of calls to execute. Reverts the whole batch on the
-     *         first failing call.
-     */
-    function execute(Multicall[] calldata calls) external payable nonReentrant {
-        if (msg.sender != address(this)) revert Unauthorized();
-        _execute(calls);
-        emit BatchExecuted(address(this), 0, calls.length);
-    }
-
-    /**
-     * @notice Sponsored batch execution. Any caller may relay the batch as long as it is
-     *         authorized by an EIP-712 signature from this account's key over
-     *         `(calls, batchNonce)`. Consumes and increments the stored nonce.
-     * @param  calls      The ordered list of calls to execute.
-     * @param  batchNonce Must equal the account's current stored nonce.
-     * @param  signature  ECDSA signature by `address(this)` over the EIP-712 digest.
-     */
-    function execute(Multicall[] calldata calls, uint256 batchNonce, bytes calldata signature)
-        external
-        payable
-        nonReentrant
-    {
-        ExecutorStorage storage $ = _s();
-        uint256 current = $.nonce;
-        if (batchNonce != current) revert InvalidNonce(current, batchNonce);
-
-        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator(), _hashBatch(calls, batchNonce)));
-        address signer = digest.recover(signature);
-        // The authorizing key must be this very account (the EOA that delegated to us).
-        if (signer != address(this)) revert Unauthorized();
-
-        unchecked {
-            $.nonce = current + 1;
-        }
-
-        _execute(calls);
-        emit BatchExecuted(address(this), batchNonce, calls.length);
-    }
-
-    // =========================
-    //        INTERNAL
-    // =========================
-
-    /// @dev Executes calls sequentially, bubbling up the original revert reason on failure.
-    function _execute(Multicall[] calldata calls) private {
-        for (uint256 i = 0; i < calls.length; ++i) {
-            (bool ok, bytes memory ret) = calls[i].to.call{value: calls[i].value}(calls[i].data);
-            if (!ok) {
-                // Bubble up the underlying revert reason if present; otherwise a typed error.
-                if (ret.length > 0) {
-                    assembly {
-                        revert(add(ret, 0x20), mload(ret))
-                    }
-                }
-                revert CallReverted(i);
-            }
-        }
-    }
-
-    /// @dev EIP-712 struct hash for the `Execute` payload.
-    function _hashBatch(Multicall[] calldata calls, uint256 batchNonce) private pure returns (bytes32) {
-        bytes32[] memory callHashes = new bytes32[](calls.length);
-        for (uint256 i = 0; i < calls.length; ++i) {
-            callHashes[i] =
-                keccak256(abi.encode(CALL_TYPEHASH, calls[i].to, calls[i].value, keccak256(calls[i].data)));
-        }
-        return keccak256(abi.encode(EXECUTE_TYPEHASH, keccak256(abi.encodePacked(callHashes)), batchNonce));
-    }
-
-    /// @notice Accept native value (e.g. funding the account before a batch with `value` calls).
+    /// @notice Accept plain native (PC) transfers. Required under EIP-7702: an
+    ///         empty-calldata value transfer to a delegated EOA dispatches here,
+    ///         and would revert without a payable `receive()`. ERC7821 has none.
     receive() external payable {}
 }

--- a/packages/core/src/lib/universal/signer/signer.spec.ts
+++ b/packages/core/src/lib/universal/signer/signer.spec.ts
@@ -87,6 +87,48 @@ describe('UniversalSigner utilities', () => {
     });
   });
 
+  describe('toUniversalFromKeypair - EIP-7702 capability gating (viem)', () => {
+    // viem exposes the `signAuthorization` action on EVERY WalletClient, so the
+    // capability must be gated on the *account* (only local accounts can sign
+    // an authorization offline), not on the client method.
+    it('exposes signAuthorization for a local account', async () => {
+      const account = privateKeyToAccount(generatePrivateKey());
+      const client = {
+        account, // local account → has account.signAuthorization
+        getAddresses: jest.fn().mockResolvedValue([account.address]),
+        signMessage: jest.fn().mockResolvedValue('0xabc'),
+        sendTransaction: jest.fn(),
+        signTypedData: jest.fn(),
+        signAuthorization: jest.fn(),
+      } as unknown as WalletClient;
+      const signer = await toUniversalFromKeypair(client, {
+        chain: CHAIN.ETHEREUM_SEPOLIA,
+        library: LIBRARY.ETHEREUM_VIEM,
+      });
+      expect(typeof signer.signAuthorization).toBe('function');
+    });
+
+    it('omits signAuthorization for a JSON-RPC account', async () => {
+      const jsonRpcAccount = {
+        address: '0x1111111111111111111111111111111111111111',
+        type: 'json-rpc',
+      };
+      const client = {
+        account: jsonRpcAccount, // no account.signAuthorization → cannot sign offline
+        getAddresses: jest.fn().mockResolvedValue([jsonRpcAccount.address]),
+        signMessage: jest.fn().mockResolvedValue('0xabc'),
+        sendTransaction: jest.fn(),
+        signTypedData: jest.fn(),
+        signAuthorization: jest.fn(), // present on the client, must NOT be trusted
+      } as unknown as WalletClient;
+      const signer = await toUniversalFromKeypair(client, {
+        chain: CHAIN.ETHEREUM_SEPOLIA,
+        library: LIBRARY.ETHEREUM_VIEM,
+      });
+      expect(signer.signAuthorization).toBeUndefined();
+    });
+  });
+
   describe('toUniversalFromKeypair - ethers v6', () => {
     const pk = generatePrivateKey();
     const mockProvider = {

--- a/packages/core/src/lib/universal/signer/signer.ts
+++ b/packages/core/src/lib/universal/signer/signer.ts
@@ -9,6 +9,8 @@ import { TypedDataDomain, TypedData } from '../../constants';
 import {
   EthersV5SignerType,
   EthersV6SignerType,
+  SignAuthorizationParams,
+  SignedAuthorization,
   UniversalAccount,
   UniversalSigner,
   UniversalSignerSkeleton,
@@ -33,10 +35,93 @@ import { bs58 } from '../../internal/bs58';
 /**
  * Converts viem's parsed transaction to an ethers-compatible TransactionRequest.
  * viem uses `gas` while ethers expects `gasLimit`.
+ *
+ * For EIP-7702 (type-4) transactions the `authorizationList` entries also need
+ * reshaping: viem represents the signature inline (`r`/`s`/`yParity`), whereas
+ * ethers expects a nested `signature`. Without this conversion ethers normalises
+ * the entry to a zero signature and the delegation is silently dropped.
  */
-function toEthersTxRequest(viemTx: ReturnType<typeof parseTransaction>): Record<string, unknown> {
-  const { gas, type, ...rest } = viemTx as Record<string, unknown>;
-  return { ...rest, gasLimit: gas };
+function toEthersTxRequest(
+  viemTx: ReturnType<typeof parseTransaction>
+): Record<string, unknown> {
+  const { gas, type, authorizationList, ...rest } = viemTx as Record<
+    string,
+    any
+  >;
+  const out: Record<string, unknown> = { ...rest, gasLimit: gas };
+  if (Array.isArray(authorizationList) && authorizationList.length > 0) {
+    out['type'] = 4;
+    out['authorizationList'] = authorizationList.map((a: any) => ({
+      address: a.address ?? a.contractAddress,
+      chainId: a.chainId,
+      nonce: a.nonce,
+      signature: { r: a.r, s: a.s, yParity: a.yParity },
+    }));
+  }
+  return out;
+}
+
+/**
+ * Builds an EIP-7702 `signAuthorization` for a viem WalletClient, but ONLY when
+ * the underlying account can sign offline (a local account). viem exposes the
+ * `signAuthorization` action on every client — including JSON-RPC accounts that
+ * cannot actually produce one — so we gate on `account.signAuthorization`
+ * (present on local accounts only). Returns `undefined` otherwise so callers
+ * fall back to non-7702 execution.
+ */
+function viemSignAuthorization(
+  wallet: any,
+  address: string
+):
+  | ((params: SignAuthorizationParams) => Promise<SignedAuthorization>)
+  | undefined {
+  const account = wallet?.account;
+  if (!account || typeof account.signAuthorization !== 'function') {
+    return undefined;
+  }
+  return async ({ contractAddress, chainId, nonce, executor }) => {
+    const auth = await wallet.signAuthorization({
+      account: account || (address as `0x${string}`),
+      contractAddress,
+      ...(chainId !== undefined ? { chainId } : {}),
+      ...(nonce !== undefined ? { nonce } : {}),
+      ...(executor ? { executor } : {}),
+    });
+    return auth as SignedAuthorization;
+  };
+}
+
+/**
+ * Builds an EIP-7702 `signAuthorization` for an ethers v6 signer. Presence of
+ * `authorize` is not a reliable capability signal (AbstractSigner's default
+ * throws), so callers MUST also handle a runtime failure and fall back — see
+ * `EIP7702NotSupportedError` in evm-client. Returns `undefined` when the method
+ * is entirely absent (e.g. ethers v5).
+ */
+function ethersSignAuthorization(
+  wallet: any,
+  chain: CHAIN
+):
+  | ((params: SignAuthorizationParams) => Promise<SignedAuthorization>)
+  | undefined {
+  if (typeof wallet?.authorize !== 'function') return undefined;
+  return async ({ contractAddress, chainId, nonce }) => {
+    const cid = chainId ?? Number(chain.split(':')[1]);
+    const auth = await wallet.authorize({
+      address: contractAddress,
+      chainId: cid,
+      nonce: nonce ?? 0,
+    });
+    const sig = auth.signature;
+    return {
+      address: contractAddress,
+      chainId: Number(auth.chainId ?? cid),
+      nonce: Number(auth.nonce ?? nonce ?? 0),
+      r: sig.r as `0x${string}`,
+      s: sig.s as `0x${string}`,
+      yParity: Number(sig.yParity),
+    };
+  };
 }
 
 /**
@@ -91,12 +176,14 @@ export function createUniversalSigner({
   signMessage,
   signAndSendTransaction,
   signTypedData,
+  signAuthorization,
 }: UniversalSigner): UniversalSigner {
   return {
     account,
     signMessage,
     signAndSendTransaction,
     signTypedData,
+    signAuthorization,
   };
 }
 
@@ -125,6 +212,12 @@ export async function toUniversalFromKeypair(
     primaryType: string;
     message: Record<string, any>;
   }) => Promise<Uint8Array>;
+  // Optional: only set for EVM wallets that support EIP-7702 authorization
+  // signing. Left undefined for Solana and wallets without 7702 support, in
+  // which case callers fall back to a non-7702 path.
+  let signAuthorization:
+    | ((params: SignAuthorizationParams) => Promise<SignedAuthorization>)
+    | undefined;
 
   // Check if signer has UID='custom', then we take signMessage, signAndSendTransaction, signTypedData, chain and address from the CustomUniversalSigner.
   // If ViemSigner, convert ViemSigner to UniversalSigner.
@@ -178,6 +271,10 @@ export async function toUniversalFromKeypair(
         return hexToBytes(sigHex as Hex);
       };
 
+      // EIP-7702 authorization signing (ethers v6). Backed by a runtime
+      // fallback in evm-client since `authorize` presence isn't a guarantee.
+      signAuthorization = ethersSignAuthorization(wallet, chain);
+
       break;
     }
 
@@ -211,6 +308,10 @@ export async function toUniversalFromKeypair(
         });
         return hexToBytes(hexSig);
       };
+
+      // EIP-7702 authorization signing — only for local viem accounts that can
+      // sign offline (gated inside the helper); JSON-RPC accounts fall back.
+      signAuthorization = viemSignAuthorization(wallet, address);
       break;
     }
 
@@ -295,6 +396,7 @@ export async function toUniversalFromKeypair(
     signMessage,
     signAndSendTransaction,
     signTypedData,
+    signAuthorization,
   };
   return createUniversalSigner(universalSigner);
 }
@@ -443,6 +545,8 @@ async function generateSkeletonFromEthersV6(
       );
       return hexToBytes(sigHex as Hex);
     },
+
+    signAuthorization: ethersSignAuthorization(signer, chain),
   };
 }
 
@@ -501,5 +605,8 @@ async function generateSkeletonFromViem(
       });
       return hexToBytes(hexSig);
     },
+
+    // Gated on a local account inside the helper (JSON-RPC accounts → undefined).
+    signAuthorization: viemSignAuthorization(signer, address),
   };
 }

--- a/packages/core/src/lib/universal/universal.types.ts
+++ b/packages/core/src/lib/universal/universal.types.ts
@@ -61,6 +61,37 @@ export interface EthersV6SignerType {
 }
 
 /**
+ * Parameters for signing an EIP-7702 authorization (delegating an EOA's code to
+ * `contractAddress`).
+ */
+export type SignAuthorizationParams = {
+  /** Address of the contract to delegate the EOA's code to. */
+  contractAddress: `0x${string}`;
+  /** Chain id for the delegation. Defaults to the signer's chain. */
+  chainId?: number;
+  /** Authorization nonce. Omit to let the wallet fill it. */
+  nonce?: number;
+  /**
+   * Set `'self'` when the signing EOA also submits the type-4 transaction; the
+   * wallet then bumps the authorization nonce by one. Prefer passing an explicit
+   * `nonce` for deterministic self-execution.
+   */
+  executor?: 'self';
+};
+
+/** A signed EIP-7702 authorization (viem-compatible shape). */
+export type SignedAuthorization = {
+  /** Address of the contract the EOA's code is delegated to. */
+  address: `0x${string}`;
+  chainId: number;
+  nonce: number;
+  r: `0x${string}`;
+  s: `0x${string}`;
+  yParity: number;
+  v?: bigint;
+};
+
+/**
  * A signer capable of signing messages for a specific chain.
  * Used to abstract away signing across multiple VM types.
  */
@@ -104,6 +135,16 @@ export interface UniversalSigner {
    * Used for sending on-chain transactions.
    */
   signAndSendTransaction: (unsignedTx: Uint8Array) => Promise<Uint8Array>;
+
+  /**
+   * Signs an EIP-7702 authorization, delegating the EOA's code to
+   * `contractAddress`. Optional — only EVM signers whose underlying wallet
+   * supports EIP-7702 implement it. When absent, callers must fall back to a
+   * non-7702 path (e.g. sequential single calls).
+   */
+  signAuthorization?: (
+    params: SignAuthorizationParams
+  ) => Promise<SignedAuthorization>;
 }
 
 export interface UniversalSignerSkeleton {
@@ -111,6 +152,9 @@ export interface UniversalSignerSkeleton {
   account: UniversalAccount;
   signMessage: (data: Uint8Array) => Promise<Uint8Array>;
   signAndSendTransaction: (unsignedTx: Uint8Array) => Promise<Uint8Array>;
+  signAuthorization?: (
+    params: SignAuthorizationParams
+  ) => Promise<SignedAuthorization>;
   signTypedData?: ({
     domain,
     types,

--- a/packages/core/src/lib/vm-client/evm-client.ts
+++ b/packages/core/src/lib/vm-client/evm-client.ts
@@ -20,6 +20,40 @@ import {
   TransactionReceipt,
 } from 'viem';
 /**
+ * ABI of `PushBatchExecutor.execute((address,uint256,bytes)[])` — the
+ * self-sponsored entrypoint invoked by a native Push EOA after it delegates its
+ * code to the executor via EIP-7702.
+ */
+const PUSH_BATCH_EXECUTOR_ABI = parseAbi([
+  'function execute((address to, uint256 value, bytes data)[] calls) payable',
+]);
+
+/** A single call in a 7702 batch. */
+export type BatchCall = {
+  to: `0x${string}`;
+  value: bigint;
+  data: `0x${string}`;
+};
+
+/**
+ * Thrown by {@link EvmClient.sendBatch7702} when the signer cannot actually
+ * produce an EIP-7702 authorization — either the capability is absent, or the
+ * wallet exposes a `signAuthorization`/`authorize` method that throws at call
+ * time (e.g. viem JSON-RPC accounts, ethers' default `AbstractSigner.authorize`).
+ *
+ * It is raised strictly BEFORE any transaction is broadcast, so callers may
+ * safely fall back to a non-7702 path without risk of double execution.
+ */
+export class EIP7702NotSupportedError extends Error {
+  readonly reason?: unknown;
+  constructor(reason?: unknown) {
+    super('Signer cannot produce an EIP-7702 authorization');
+    this.name = 'EIP7702NotSupportedError';
+    this.reason = reason;
+  }
+}
+
+/**
  * EVM client for reading and writing to Ethereum-compatible chains
  *
  * @example
@@ -256,6 +290,113 @@ export class EvmClient {
       hexToBytes(unsignedTx)
     );
 
+    return bytesToHex(txHashBytes);
+  }
+
+  /**
+   * Executes a batch of calls atomically from a native EOA using EIP-7702.
+   *
+   * The EOA signs an authorization delegating its code to `executor`
+   * (`PushBatchExecutor`) and submits a single type-4 transaction calling
+   * `execute(calls)` on itself. Because the authority equals the transaction
+   * sender, the executor's self-call check authorizes the batch — no per-call
+   * signature is needed. All calls succeed or the whole tx reverts.
+   *
+   * Requires `signer.signAuthorization` (EIP-7702 capable wallet). Callers
+   * should check for it and fall back to sequential execution when absent.
+   *
+   * @returns The transaction hash.
+   */
+  async sendBatch7702({
+    executor,
+    calls,
+    signer,
+  }: {
+    executor: `0x${string}`;
+    calls: BatchCall[];
+    signer: UniversalSigner;
+  }): Promise<Hex> {
+    if (!signer.signAuthorization) {
+      // No capability at all → safe pre-broadcast signal to fall back.
+      throw new EIP7702NotSupportedError();
+    }
+    if (!signer.signAndSendTransaction) {
+      throw new Error('signer.signAndSendTransaction is undefined');
+    }
+
+    const account = signer.account.address as `0x${string}`;
+    const data = encodeFunctionData({
+      abi: PUSH_BATCH_EXECUTOR_ABI,
+      functionName: 'execute',
+      args: [calls.map((c) => ({ to: c.to, value: c.value, data: c.data }))],
+    });
+
+    const [feePerGas, chainId, nonce] = await Promise.all([
+      this.publicClient.estimateFeesPerGas(),
+      this.publicClient.getChainId(),
+      this.publicClient.getTransactionCount({
+        address: account,
+        blockTag: 'pending',
+      }),
+    ]);
+
+    // EIP-7702 self-execution: the transaction consumes `nonce`, so the
+    // authorization (validated after the sender's nonce is bumped) must carry
+    // `nonce + 1`. This is the only step that can reveal the wallet truly can't
+    // sign a 7702 authorization (presence of the method is not a guarantee), so
+    // a failure here is surfaced as EIP7702NotSupportedError — pre-broadcast,
+    // hence safe for the caller to fall back on.
+    let authorization;
+    try {
+      authorization = await signer.signAuthorization({
+        contractAddress: executor,
+        chainId,
+        nonce: nonce + 1,
+      });
+    } catch (err) {
+      throw new EIP7702NotSupportedError(err);
+    }
+
+    // Estimate gas against the delegated account: override the EOA's code with
+    // the 7702 delegation designator (0xef0100 || executor) so estimation runs
+    // the executor. Fall back to a safe ceiling if the node rejects overrides.
+    let gas: bigint;
+    try {
+      gas = await this.publicClient.estimateGas({
+        account,
+        to: account,
+        data,
+        stateOverride: [
+          {
+            address: account,
+            code: ('0xef0100' + executor.slice(2)) as Hex,
+          },
+        ],
+      });
+      gas = (gas * BigInt(120)) / BigInt(100); // headroom for delegation + auth
+    } catch {
+      // Estimation unavailable (e.g. node rejects state overrides). Scale the
+      // ceiling with the batch size so large batches don't OOG — the legacy
+      // per-call loop budgeted ~500k gas per call; mirror that plus overhead.
+      gas = BigInt(500_000) * BigInt(calls.length) + BigInt(100_000);
+    }
+
+    const unsignedTx = serializeTransaction({
+      chainId,
+      type: 'eip7702',
+      to: account,
+      data,
+      gas,
+      nonce,
+      maxFeePerGas: feePerGas.maxFeePerGas,
+      maxPriorityFeePerGas: feePerGas.maxPriorityFeePerGas,
+      value: BigInt(0),
+      authorizationList: [authorization as never],
+    });
+
+    const txHashBytes = await signer.signAndSendTransaction(
+      hexToBytes(unsignedTx)
+    );
     return bytesToHex(txHashBytes);
   }
 

--- a/packages/core/src/lib/vm-client/evm-client.ts
+++ b/packages/core/src/lib/vm-client/evm-client.ts
@@ -8,6 +8,7 @@ import {
 import {
   bytesToHex,
   createPublicClient,
+  encodeAbiParameters,
   encodeFunctionData,
   hexToBytes,
   http,
@@ -20,13 +21,35 @@ import {
   TransactionReceipt,
 } from 'viem';
 /**
- * ABI of `PushBatchExecutor.execute((address,uint256,bytes)[])` — the
- * self-sponsored entrypoint invoked by a native Push EOA after it delegates its
- * code to the executor via EIP-7702.
+ * ABI of the ERC-7821 `execute(bytes32 mode, bytes executionData)` entrypoint —
+ * invoked by a native Push EOA on itself after it delegates its code to the
+ * executor (`PushBatchExecutor is ERC7821`) via EIP-7702. ERC-7821's default
+ * authorization (`caller == address(this)`) is exactly that self-call.
  */
 const PUSH_BATCH_EXECUTOR_ABI = parseAbi([
-  'function execute((address to, uint256 value, bytes data)[] calls) payable',
+  'function execute(bytes32 mode, bytes executionData) payable',
 ]);
+
+/**
+ * ERC-7821 single-batch execution mode: callType `0x01` (batch) in the top byte,
+ * default exec type and zero mode-selector — i.e. `0x01` followed by 31 zero
+ * bytes. This is the only mode the executor supports.
+ */
+const ERC7821_BATCH_MODE =
+  '0x0100000000000000000000000000000000000000000000000000000000000000' as const;
+
+/**
+ * ABI tuple for an ERC-7821 / ERC-7579 `Execution`. `executionData` for a batch
+ * is `abi.encode(Execution[])`.
+ */
+const ERC7821_EXECUTION_TUPLE = {
+  type: 'tuple[]',
+  components: [
+    { name: 'target', type: 'address' },
+    { name: 'value', type: 'uint256' },
+    { name: 'callData', type: 'bytes' },
+  ],
+} as const;
 
 /** A single call in a 7702 batch. */
 export type BatchCall = {
@@ -297,13 +320,18 @@ export class EvmClient {
    * Executes a batch of calls atomically from a native EOA using EIP-7702.
    *
    * The EOA signs an authorization delegating its code to `executor`
-   * (`PushBatchExecutor`) and submits a single type-4 transaction calling
-   * `execute(calls)` on itself. Because the authority equals the transaction
-   * sender, the executor's self-call check authorizes the batch — no per-call
-   * signature is needed. All calls succeed or the whole tx reverts.
+   * (`PushBatchExecutor`, an ERC-7821 executor) and submits a single type-4
+   * transaction calling `execute(mode, executionData)` on itself. Because the
+   * authority equals the transaction sender, ERC-7821's self-call check
+   * authorizes the batch — no per-call signature is needed. All calls succeed
+   * or the whole tx reverts.
    *
    * Requires `signer.signAuthorization` (EIP-7702 capable wallet). Callers
    * should check for it and fall back to sequential execution when absent.
+   *
+   * Rejects a zero `to` address: ERC-7579/7821 reinterprets `target == 0` as
+   * `address(this)`, which would silently differ from the sequential fallback
+   * (which sends to the zero address). Disallow it so behaviour is consistent.
    *
    * @returns The transaction hash.
    */
@@ -325,10 +353,28 @@ export class EvmClient {
     }
 
     const account = signer.account.address as `0x${string}`;
+
+    // ERC-7821 maps target == address(0) to address(this); reject it so a batch
+    // can't silently behave differently here vs. the sequential fallback.
+    if (
+      calls.some(
+        (c) => /^0x0{40}$/i.test(c.to) || c.to.toLowerCase() === '0x0'
+      )
+    ) {
+      throw new Error(
+        'sendBatch7702: a call has a zero `to` address, which ERC-7821 reinterprets ' +
+          'as the account itself. Use an explicit target.'
+      );
+    }
+
+    // ERC-7821: execute(mode, executionData) where executionData = abi.encode(Execution[]).
+    const executionData = encodeAbiParameters([ERC7821_EXECUTION_TUPLE], [
+      calls.map((c) => ({ target: c.to, value: c.value, callData: c.data })),
+    ]);
     const data = encodeFunctionData({
       abi: PUSH_BATCH_EXECUTOR_ABI,
       functionName: 'execute',
-      args: [calls.map((c) => ({ to: c.to, value: c.value, data: c.data }))],
+      args: [ERC7821_BATCH_MODE, executionData],
     });
 
     const [feePerGas, chainId, nonce] = await Promise.all([


### PR DESCRIPTION
PushBatchExecutor is the delegation target a secp256k1 EOA (EVM-origin or native Push) points its code to via EIP-7702 to execute a Multicall[] batch atomically in one tx — replacing the custom UEA_MULTICALL path for those accounts. SVM accounts cannot sign a 7702 authorization and keep UEA_MULTICALL.

- self-sponsored execute(Multicall[]) gated on msg.sender == address(this)
- sponsored execute(Multicall[], nonce, sig) via EIP-712 with replay-safe nonce
- sequential execution, revert bubbling, ERC-7201 namespaced storage (runs in the EOA's storage under delegation)
- 8 Foundry tests under real 7702 delegation; deploy script
- deployed to Push Testnet Donut at 0x0106BF2F9B02f32203A83a3bDaD79fE8818f3796

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] This PR does not contain plagiarized content.
- [ ] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
