### PR TITLE
docs: fix links and add link checker

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,35 @@
+name: Check links
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  links:
+    name: Check repository links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Check Markdown links
+        uses: lycheeverse/lychee-action@v2.4.0
+        with:
+          args: --verbose --no-progress './**/*.md' './**/*.mdx'
+          fail: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload link-checker report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: link-checker-report
+          path: lychee-out.md
+          if-no-files-found: ignore
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ Click on the packages to view more details.
 
 - **[Website](https://push.org)** To checkout our Product.
 - **[Docs](https://push.org/docs)** For comprehensive documentation.
-- **[Blog](https://medium.com/push-protocol)** To learn more about our partners, new launches, etc.
+- **[Blog](https://push.org/blog)** To learn more about our partners, new launches, etc.
 - **[Discord](https://discord.com/invite/pushchain)** for support and discussions with the community and the team.
-- **[GitHub](https://github.com/push-protocol)** for source code, project board, issues, and pull requests.
+- **[GitHub](https://github.com/pushchain)** for source code, project board, issues, and pull requests.
 - **[X/Twitter](https://x.com/pushchain)** for the latest updates on the product and published blogs.
 
 ## Contributing
@@ -56,7 +56,7 @@ Push Protocol is an open source Project. We firmly believe in a completely trans
 - Feature Request: Please submit a feature request if you have an idea or discover a capability that would make development simpler and more reliable.
 - Documentation Request: If you're reading the Push documentation and believe that we're missing something, please create a docs request.
 
-<!-- Read how you can contribute <a href="https://github.com/push-protocol/push-chain-sdk/blob/main/CONTRIBUTING.md
+<!-- Read how you can contribute <a href="https://github.com/pushchain/push-chain-sdk/blob/main/CONTRIBUTING.md
 ">HERE</a> -->
 
 Not sure where to start? Join our discord and we will help you get started!


### PR DESCRIPTION
Closes #192

## Fixes Issue

The README referenced the retired `push-protocol` organization and blog location.

## Changes proposed

- Updated the blog link to `https://push.org/blog`.
- - Updated the GitHub organization link to `https://github.com/pushchain`.
- - Updated the contributing-guide reference to the current repository path.
- - Added `.github/workflows/check-links.yml` to check Markdown and MDX links on pull requests and pushes to `main`.
- - Added a short-lived workflow artifact for the link-checker report.
## Check List

- [x] My code follows the code style of this project.
- [ ] - [x] My change requires changes to the documentation.
- [ ] - [x] I have updated the documentation accordingly.
- [ ] - [x] This PR does not contain plagiarized content.
- [ ] - [x] The title of my pull request is a short description of the requested changes.
## Note to reviewers

`git diff --check` passed. URL replacements were verified with HTTP requests.