### PR TITLE
fix(ui-kit): stop forwarding stale gas/fee estimates to injected wallets

### DIFF
--- a/.changeset/fix-injected-wallet-fee-overrides.md
+++ b/.changeset/fix-injected-wallet-fee-overrides.md
@@ -1,0 +1,9 @@
+---
+'@pushchain/ui-kit': patch
+---
+
+Fix `-32003` "Transaction rejected" errors from injected/embedded wallets by no longer forwarding Core's pre-estimated `gas`, `maxFeePerGas`, and `maxPriorityFeePerGas` into `eth_sendTransaction`.
+
+Every wallet adapter (`MetamaskProvider`, `RabbyProvider`, `ZerionProvider`, the WalletConnect adapter, the Phantom EVM adapter, and the WAAP embedded-wallet provider) parsed the unsigned transaction Core serialized and relayed its `gas`/`maxFeePerGas`/`maxPriorityFeePerGas` fields verbatim into `eth_sendTransaction`. Those values are estimated by Core against its own RPC, before the wallet-approval popup even opens; the wallet then broadcasts through its *own* configured RPC. If the two disagree, or the fee estimate goes stale during the approval wait, the broadcasting node can reject the transaction outright with JSON-RPC `-32003` — surfaced to users as a "Signature Failed" toast even though they'd already approved.
+
+Adapters now send only `from`/`to`/`value`/`data` and let each wallet estimate gas and fees itself, against its own RPC, immediately before broadcast — eliminating the estimate-vs-broadcast mismatch. Core is unaffected: it still computes and serializes complete transactions (used as-is by local/raw signers), this change only touches what the injected-wallet adapters choose to forward.

--- a/packages/ui-kit/src/lib/providers/waap/waapProvider.ts
+++ b/packages/ui-kit/src/lib/providers/waap/waapProvider.ts
@@ -168,18 +168,19 @@ export const waapSignAndSendTransaction = async (
 	const hex = bytesToHex(txn);
 	const parsed = parseTransaction(hex);
 
+	// Deliberately omit gas / maxFeePerGas / maxPriorityFeePerGas: those were
+	// estimated by Core against its own RPC, which can disagree with (or go
+	// stale relative to) whatever RPC the WAAP provider itself broadcasts
+	// through, causing spurious -32003 "Transaction rejected" errors after
+	// the user has already approved. Letting the provider estimate gas/fees
+	// itself, right before it broadcasts, avoids that estimate-vs-broadcast
+	// mismatch entirely. (See the same fix applied to the injected-wallet
+	// adapters in ../walletProviders/ethereum/.)
 	const txParams = {
 		from: accounts[0],
 		to: parsed.to,
 		value: parsed.value ? "0x" + parsed.value.toString(16) : undefined,
 		data: parsed.data,
-		gas: parsed.gas ? "0x" + parsed.gas.toString(16) : undefined,
-		maxPriorityFeePerGas: parsed.maxPriorityFeePerGas
-			? "0x" + parsed.maxPriorityFeePerGas.toString(16)
-			: undefined,
-		maxFeePerGas: parsed.maxFeePerGas
-			? "0x" + parsed.maxFeePerGas.toString(16)
-			: undefined,
 	};
 
 	const res = await provider.request({

--- a/packages/ui-kit/src/lib/providers/walletProviders/ethereum/metamask.ts
+++ b/packages/ui-kit/src/lib/providers/walletProviders/ethereum/metamask.ts
@@ -143,18 +143,18 @@ export class MetamaskProvider extends BaseWalletProvider {
       const hex = bytesToHex(txn);
       const parsed = parseTransaction(hex);
 
+      // Deliberately omit gas / maxFeePerGas / maxPriorityFeePerGas: those
+      // were estimated by Core against its own RPC, which can disagree with
+      // (or go stale relative to) whatever RPC MetaMask itself broadcasts
+      // through, causing spurious -32003 "Transaction rejected" errors after
+      // the user has already approved. Letting MetaMask estimate gas/fees
+      // itself, against its own RPC, right before it broadcasts, avoids that
+      // estimate-vs-broadcast mismatch entirely.
       const txParams = {
         from: accounts[0],
         to: parsed.to,
         value: parsed.value ? '0x' + parsed.value.toString(16) : undefined,
         data: parsed.data,
-        gas: parsed.gas ? '0x' + parsed.gas.toString(16) : undefined,
-        maxPriorityFeePerGas: parsed.maxPriorityFeePerGas
-          ? '0x' + parsed.maxPriorityFeePerGas.toString(16)
-          : undefined,
-        maxFeePerGas: parsed.maxFeePerGas
-          ? '0x' + parsed.maxFeePerGas.toString(16)
-          : undefined,
       };
 
       const signature = await provider.request({

--- a/packages/ui-kit/src/lib/providers/walletProviders/ethereum/rabby.ts
+++ b/packages/ui-kit/src/lib/providers/walletProviders/ethereum/rabby.ts
@@ -144,18 +144,18 @@ export class RabbyProvider extends BaseWalletProvider {
     const hex = bytesToHex(txn);
     const parsed = parseTransaction(hex);
 
+    // Deliberately omit gas / maxFeePerGas / maxPriorityFeePerGas: those were
+    // estimated by Core against its own RPC, which can disagree with (or go
+    // stale relative to) whatever RPC Rabby itself broadcasts through,
+    // causing spurious -32003 "Transaction rejected" errors after the user
+    // has already approved. Letting Rabby estimate gas/fees itself, against
+    // its own RPC, right before it broadcasts, avoids that estimate-vs-
+    // broadcast mismatch entirely.
     const txParams = {
       from: accounts[0],
       to: parsed.to,
       value: parsed.value ? '0x' + parsed.value.toString(16) : undefined,
       data: parsed.data,
-      gas: parsed.gas ? '0x' + parsed.gas.toString(16) : undefined,
-      maxPriorityFeePerGas: parsed.maxPriorityFeePerGas
-        ? '0x' + parsed.maxPriorityFeePerGas.toString(16)
-        : undefined,
-      maxFeePerGas: parsed.maxFeePerGas
-        ? '0x' + parsed.maxFeePerGas.toString(16)
-        : undefined,
     };
 
     const txHash = await provider.request({

--- a/packages/ui-kit/src/lib/providers/walletProviders/ethereum/walletConnect.ts
+++ b/packages/ui-kit/src/lib/providers/walletProviders/ethereum/walletConnect.ts
@@ -127,18 +127,18 @@ export class WalletConnectProvider extends BaseWalletProvider {
       const hex = bytesToHex(txn);
       const parsed = parseTransaction(hex);
 
+      // Deliberately omit gas / maxFeePerGas / maxPriorityFeePerGas: those
+      // were estimated by Core against its own RPC, which can disagree with
+      // (or go stale relative to) whatever RPC the connected wallet itself
+      // broadcasts through, causing spurious -32003 "Transaction rejected"
+      // errors after the user has already approved. Letting the wallet
+      // estimate gas/fees itself, against its own RPC, right before it
+      // broadcasts, avoids that estimate-vs-broadcast mismatch entirely.
       const txParams = {
         from: accounts[0],
         to: parsed.to,
         value: parsed.value ? '0x' + parsed.value.toString(16) : undefined,
         data: parsed.data,
-        gas: parsed.gas ? '0x' + parsed.gas.toString(16) : undefined,
-        maxPriorityFeePerGas: parsed.maxPriorityFeePerGas
-          ? '0x' + parsed.maxPriorityFeePerGas.toString(16)
-          : undefined,
-        maxFeePerGas: parsed.maxFeePerGas
-          ? '0x' + parsed.maxFeePerGas.toString(16)
-          : undefined,
       };
 
       const signature = await provider.request({

--- a/packages/ui-kit/src/lib/providers/walletProviders/ethereum/zerion.ts
+++ b/packages/ui-kit/src/lib/providers/walletProviders/ethereum/zerion.ts
@@ -150,18 +150,18 @@ export class ZerionProvider extends BaseWalletProvider {
     const hex = bytesToHex(txn);
     const parsed = parseTransaction(hex);
 
+    // Deliberately omit gas / maxFeePerGas / maxPriorityFeePerGas: those were
+    // estimated by Core against its own RPC, which can disagree with (or go
+    // stale relative to) whatever RPC Zerion itself broadcasts through,
+    // causing spurious -32003 "Transaction rejected" errors after the user
+    // has already approved. Letting Zerion estimate gas/fees itself, against
+    // its own RPC, right before it broadcasts, avoids that estimate-vs-
+    // broadcast mismatch entirely.
     const txParams = {
       from: accounts[0],
       to: parsed.to,
       value: parsed.value ? '0x' + parsed.value.toString(16) : undefined,
       data: parsed.data,
-      gas: parsed.gas ? '0x' + parsed.gas.toString(16) : undefined,
-      maxPriorityFeePerGas: parsed.maxPriorityFeePerGas
-        ? '0x' + parsed.maxPriorityFeePerGas.toString(16)
-        : undefined,
-      maxFeePerGas: parsed.maxFeePerGas
-        ? '0x' + parsed.maxFeePerGas.toString(16)
-        : undefined,
     };
 
     const txHash = await provider.request({

--- a/packages/ui-kit/src/lib/providers/walletProviders/solana/phantom.ts
+++ b/packages/ui-kit/src/lib/providers/walletProviders/solana/phantom.ts
@@ -244,18 +244,18 @@ export class PhantomProvider extends BaseWalletProvider {
         const hex = bytesToHex(txn);
         const parsed = parseTransaction(hex);
 
+        // Deliberately omit gas / maxFeePerGas / maxPriorityFeePerGas: those
+        // were estimated by Core against its own RPC, which can disagree
+        // with (or go stale relative to) whatever RPC Phantom itself
+        // broadcasts through, causing spurious -32003 "Transaction rejected"
+        // errors after the user has already approved. Letting Phantom
+        // estimate gas/fees itself, against its own RPC, right before it
+        // broadcasts, avoids that estimate-vs-broadcast mismatch entirely.
         const txParams = {
           from: accounts[0],
           to: parsed.to,
           value: parsed.value ? '0x' + parsed.value.toString(16) : undefined,
           data: parsed.data,
-          gas: parsed.gas ? '0x' + parsed.gas.toString(16) : undefined,
-          maxPriorityFeePerGas: parsed.maxPriorityFeePerGas
-            ? '0x' + parsed.maxPriorityFeePerGas.toString(16)
-            : undefined,
-          maxFeePerGas: parsed.maxFeePerGas
-            ? '0x' + parsed.maxFeePerGas.toString(16)
-            : undefined,
         };
 
         const signature = await provider.request({


### PR DESCRIPTION
## Summary

Every injected/embedded EVM wallet adapter in `ui-kit` — `MetamaskProvider`, `RabbyProvider`, `ZerionProvider`, the WalletConnect adapter, Phantom's EVM branch, and the WAAP embedded-wallet provider — parsed Core's serialized unsigned transaction and relayed its `gas`/`maxFeePerGas`/`maxPriorityFeePerGas` fields verbatim into `eth_sendTransaction`.

`EvmClient.sendTransaction()` (Core) estimates those values against its own RPC, before the wallet-approval popup even opens. The wallet then broadcasts through its own, separately configured RPC. If the two disagree, or the estimate goes stale during the approval wait, the broadcasting node can reject the transaction outright with JSON-RPC `-32003` ("Transaction rejected") — surfaced to users as a "Signature Failed" toast even though they'd already approved.

## Fix

Send only `from`/`to`/`value`/`data` to the wallet; let it estimate gas and fees itself, against its own RPC, immediately before broadcast. This removes the estimate-vs-broadcast mismatch entirely rather than trying to keep Core's estimate fresh enough (re-estimating in Core doesn't help either — the staleness window is the wallet-approval wait itself, which happens *inside* the opaque `provider.request()` call, after control has already passed to the wallet).

Core is unaffected: it still produces complete serialized transactions with `gas`/fee fields, used as-is by local/raw signers and non-injected paths. Only what the injected-wallet adapters choose to forward to `eth_sendTransaction` changes.

## Scope

Found and fixed 6 instances of the identical copy-pasted pattern:
- `packages/ui-kit/src/lib/providers/walletProviders/ethereum/metamask.ts`
- `packages/ui-kit/src/lib/providers/walletProviders/ethereum/rabby.ts`
- `packages/ui-kit/src/lib/providers/walletProviders/ethereum/zerion.ts`
- `packages/ui-kit/src/lib/providers/walletProviders/ethereum/walletConnect.ts`
- `packages/ui-kit/src/lib/providers/walletProviders/solana/phantom.ts` (EVM branch — Phantom connected via `window.phantom.ethereum`)
- `packages/ui-kit/src/lib/providers/waap/waapProvider.ts` (embedded email/Google-login wallet)

The last two weren't part of the original diagnosis and were found by grepping the whole repo for the same fingerprint (`gas: parsed.gas`) — confirmed zero remaining instances after the fix.

## Verification

- `nx run ui-kit:lint` — 0 errors (48 pre-existing warnings, unrelated to this change)
- `nx run ui-kit:build` — compiles cleanly (core + ui-kit)
- `nx run ui-kit:test` — 11/11 passing, 4/4 suites
- `nx run core:test` — 1358/1371 passing; the 1 failure (`outbound-timeout-clamp.spec.ts`) is a pre-existing timing-sensitive assertion (`elapsed < 1500ms`, observed `3735ms` under load) in a file this PR doesn't touch, unrelated to this change
- No existing test asserts on the exact `eth_sendTransaction` params shape, so nothing needed updating for the removed fields

## Repro that motivated this

Minting PUSD+ on Base Sepolia via MetaMask, with `printTraces` enabled:
```
SEND-TX-104-01 'Awaiting Transaction'  — Awaiting user transaction on origin chain (INFO)
SEND-TX-104-02 'Awaiting Signature'    — Awaiting user signature for universal payload (INFO)
SEND-TX-104-03 'Verification Success'  — Verification completed via Transaction or Signature (SUCCESS)
SEND-TX-104-04 'Signature Failed'      — Transaction creation failed. (ERROR)
```
`"Transaction creation failed."` is viem's `TransactionRejectedRpcError` shortMessage for JSON-RPC `-32003`.

Note: `-32003` is a generic EIP-1474 bucket (can also represent insufficient funds, policy rejection, or malformed params) — we didn't have the nested provider error to confirm fee-cap rejection was the specific cause of that one repro. The design flaw this PR fixes is real and independently confirmed from source regardless; treat the specific repro as motivating context, not as proof of the exact failure mode in that instance.

## Out of scope / follow-ups worth a separate PR

- `SEND_TX_104_03` ("Verification Success") fires optimistically before `eth_sendTransaction` in the funds+payload path (`execute-funds-payload.ts:181`), then again after a real hash comes back (`:230`). Worth not treating the first emission as proof of a successful signature.
- Non-decline `SEND_TX_104_04` failures are titled "Signature Failed" even when the failure is a post-approval broadcast rejection. A distinct title/hook for that case would reduce user confusion.
- Preserving the full nested RPC error (`data`/`details`/`cause`) through `normalizePublicErrorMessage` would make future triage of generic `-32003`/`-32000` errors much faster.
- `CHAIN_INFO`'s `defaultRPC` lists for Arbitrum Sepolia, Base Sepolia, and BNB Testnet each contain a duplicate host (the same URL listed twice), reducing effective fallback diversity — worth deduping independently of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)